### PR TITLE
Fix to execute() to allow it to work if no params are passed to it

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TraceablePDOStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TraceablePDOStatement.php
@@ -49,7 +49,7 @@ class TraceablePDOStatement extends PDOStatement
     /**
      * {@inheritDoc}
      */
-    public function execute($params = array())
+    public function execute(array $params = null)
     {
         $start = microtime(true);
         $ex = null;
@@ -61,7 +61,10 @@ class TraceablePDOStatement extends PDOStatement
         }
 
         $preparedId = spl_object_hash($this);
-        $boundParameters = array_merge($this->boundParameters, $params);
+        $boundParameters = $this->boundParameters;
+        if (is_array($params)) {
+            $boundParameters = array_merge($boundParameters, $params);
+        }
         $duration = microtime(true) - $start;
         $memoryUsage = memory_get_usage(true);
         if ($this->pdo->getAttribute(PDO::ATTR_ERRMODE) !== PDO::ERRMODE_EXCEPTION && $result === false) {
@@ -69,7 +72,7 @@ class TraceablePDOStatement extends PDOStatement
             $ex = new PDOException($error[2], $error[0]);
         }
 
-        $tracedStmt = new TracedStatement($this->queryString, $boundParameters, 
+        $tracedStmt = new TracedStatement($this->queryString, $boundParameters,
             $preparedId, $this->rowCount(), $duration, $memoryUsage, $ex);
         $this->pdo->addExecutedStatement($tracedStmt);
 


### PR DESCRIPTION
Hi,

I came across an issue when attempting to use the PDO data collector - calls to execute() with no parameters would fail (with a "no parameters" error or similar) if parameters were set through a bindValue() or other call.

It turned out that (in 5.3 at least, untested in other versions) that calling PDOStatement::execute() with an empty array as its parameter causes this error. This PR just sets the default to null and changes the bound parameter list to be able to work with null values.
