### PR TITLE
Fix for undefined variable in the addCollector() method

### DIFF
--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -35,13 +35,16 @@ class DebugBar implements ArrayAccess
 
     /**
      * Adds a data collector
-     * 
+     *
      * @param DataCollectorInterface $collector
+     *
+     * @throws DebugBarException
+     * @return $this
      */
     public function addCollector(DataCollectorInterface $collector)
     {
         if (isset($this->collectors[$collector->getName()])) {
-            throw new DebugBarException("'$name' is already a registered collector");
+            throw new DebugBarException("'{$collector->getName()}' is already a registered collector");
         }
         $this->collectors[$collector->getName()] = $collector;
         return $this;


### PR DESCRIPTION
The `addCollector()` method was throwing an exception that referenced an undefined variable. I also updated the method comment slightly to include @throws and @return.
