### PR TITLE
Check for NULL value

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -58,7 +58,7 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function formatBytes($size, $precision = 2)
     {
-        if ($size === 0) {
+        if ($size === 0 or is_null($size)) {
             return "0B";
         }
         $base = log($size) / log(1024);


### PR DESCRIPTION
When using PDO Datacollector (in Laravel) I got an error: `Undefined offset: -9223372036854775808`, because $size was NULL and $base was -INF.
