### PR TITLE
Recursively format vars

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -23,16 +23,25 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function formatVar($var)
     {
+        $var = $this->flattenVar($var);
+        return print_r($var, true);
+    }
+
+    /**
+     * Flatten a var recursively
+     *
+     * @param $var
+     * @return mixed
+     */
+    public function flattenVar($var){
         if (is_array($var)) {
             foreach ($var as &$v) {
-                if (is_object($v)) {
-                    $v = "Object(" . get_class($v) . ")";
-                }
+                $v = $this->flattenVar($v);
             }
         } else if (is_object($var)) {
             $var = "Object(" . get_class($var) . ")";
         }
-        return print_r($var, true);
+        return $var;
     }
 
     /**


### PR DESCRIPTION
Not sure if the name/implementation is the best, but with the old formatVars, an array with objects wasn't properly transformed.
This could lead to recursion and a blank screen..
This way every array is checked again for object, not just the first level.
