### PR TITLE
Set color to black

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -8,6 +8,7 @@ div.phpdebugbar {
   background: #fff;
   z-index: 10000;
   font-size: 14px;
+  color: #000;
 }
 
 /* -------------------------------------- */


### PR DESCRIPTION
When the site has a white text-color, the text cannot be read. Set to black by default.
