### PR TITLE
Show microseconds

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -52,9 +52,9 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function formatDuration($seconds)
     {
-        if($seconds < 0.001){
+        if ($seconds < 0.001) {
             return round($seconds * 1000000) . 'μs';
-        }elseif ($seconds < 1) {
+        } else if ($seconds < 1) {
             return round($seconds * 1000, 2) . 'ms';
         }
         return round($seconds, 2) . 's';


### PR DESCRIPTION
Many small PDO queries will report 0ms. This will show microseconds when appropriate.
