### PR TITLE
Escape HTML entities

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -40,6 +40,8 @@ abstract class DataCollector implements DataCollectorInterface
             }
         } else if (is_object($var)) {
             $var = "Object(" . get_class($var) . ")";
+        }else{
+            $var = htmlentities($var, ENT_QUOTES, 'UTF-8', false);
         }
         return $var;
     }


### PR DESCRIPTION
To prevent HTML being showed instead of the tags.

When showing an object with html values, the html was executed instead of shown plain text.
See https://github.com/barryvdh/laravel-debugbar/issues/23
