### PR TITLE
Reset box-sizing

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -12,6 +12,10 @@ div.phpdebugbar {
   text-align: left;
 }
 
+div.phpdebugbar * {
+	box-sizing: content-box;
+}
+
 /* -------------------------------------- */
 
 div.phpdebugbar-header {


### PR DESCRIPTION
By default, Bootstrap3 applies `box-sizing: border-box;` to every element. This doesn't work well for some controls, so reset it to content-box.
See https://github.com/barryvdh/laravel-debugbar/issues/26
