### PR TITLE
Check parameters for binary data

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -51,13 +51,28 @@ class TracedStatement
     {
         $this->sql = $sql;
         $this->rowCount = $rowCount;
-        $this->parameters = $params;
+        $this->parameters = $this->checkParameters($params);
         $this->preparedId = $preparedId;
         $this->startTime = $startTime;
         $this->endTime = $endTime;
         $this->duration = $endTime - $startTime;
         $this->memoryUsage = $memoryUsage;
         $this->exception = $e;
+    }
+	
+	/**
+     * Check parameters for illegal (non UTF-8) strings, like Binary data.
+     *
+     * @param $params
+     * @return mixed
+     */
+    public function checkParameters($params){
+        foreach($params as &$param){
+            if(!mb_check_encoding($param, 'UTF-8')){
+                $param = '[BINARY DATA]';
+            }
+        }
+        return $params;
     }
 
     /**


### PR DESCRIPTION
For example when saving an image as a Blob in the DB. 
Fix for issue described in https://github.com/barryvdh/laravel-debugbar/issues/27
