### PR TITLE
Escape PDO Params

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -119,6 +119,7 @@ class TracedStatement
         foreach($this->parameters as $param){
             $params[] = htmlentities($param, ENT_QUOTES, 'UTF-8', false);
         }
+        return $params;
     }
 
     /**


### PR DESCRIPTION
Escape the params, to prevent html leaking.
Fix for issue described in https://github.com/barryvdh/laravel-debugbar/issues/28
