### PR TITLE
Allow TraceablePDO to accept PDO subclasses

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TraceablePDO.php
+++ b/src/DebugBar/DataCollector/PDO/TraceablePDO.php
@@ -20,36 +20,9 @@ class TraceablePDO extends PDO
         $this->pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('DebugBar\DataCollector\PDO\TraceablePDOStatement', array($this)));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function beginTransaction()
+    public function __call($name, array $arguments)
     {
-        return $this->pdo->beginTransaction();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function commit()
-    {
-        return $this->pdo->commit();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function errorCode()
-    {
-        return $this->pdo->errorCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function errorInfo()
-    {
-        return $this->errorInfo();
+        return call_user_func_array(array($this->pdo, $name), $arguments);
     }
 
     /**
@@ -63,65 +36,9 @@ class TraceablePDO extends PDO
     /**
      * {@inheritDoc}
      */
-    public function getAttribute($attr)
-    {
-        return $this->pdo->getAttribute($attr);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function inTransaction()
-    {
-        return $this->pdo->inTransaction();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function lastInsertId($name = null)
-    {
-        return $this->pdo->lastInsertId($name);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function prepare($sql, $driver_options = array())
-    {
-        return $this->pdo->prepare($sql, $driver_options);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function query($sql)
     {
         return $this->profileCall('query', $sql, func_get_args());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function quote($expr, $parameter_type = PDO::PARAM_STR)
-    {
-        return $this->pdo->quote($expr, $parameter_type);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function rollBack()
-    {
-        return $this->pdo->rollBack();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setAttribute($attr, $value)
-    {
-        return $this->pdo->setAttribute($attr, $value);
     }
 
     /**

--- a/tests/DebugBar/Tests/DataCollector/PDO/PDFOO.php
+++ b/tests/DebugBar/Tests/DataCollector/PDO/PDFOO.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DebugBar\Tests\DataCollector\PDO;
+
+class PDFOO extends \PDO
+{
+    public function foo()
+    {
+        return 'foo';
+    }
+}

--- a/tests/DebugBar/Tests/DataCollector/PDO/TraceablePDOTest.php
+++ b/tests/DebugBar/Tests/DataCollector/PDO/TraceablePDOTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DebugBar\Tests\DataCollector\PDO;
+
+use DebugBar\Tests\DebugBarTestCase;
+use DebugBar\DataCollector\PDO\TraceablePDO;
+
+class TraceablePDOTest extends DebugBarTestCase
+{
+    public function testExec()
+    {
+        $pdo = new TraceablePDO(new \PDO('sqlite::memory:'));
+        $pdo->exec('CREATE TABLE a ( id INT NOT NULL )');
+        $this->assertEquals(1, count($pdo->getExecutedStatements()));
+    }
+
+    public function testCanCallSubclassMethods()
+    {
+        $pdo = new TraceablePDO(new PDFOO('sqlite::memory:'));
+        $this->assertSame('foo', $pdo->foo());
+    }
+}


### PR DESCRIPTION
I'm using a subclass of PDO in my code and I had to subclass TraceablePDO in order to use it. I think this change would better fit in the original TraceablePDO.

```
class TraceablePDO extends \DebugBar\DataCollector\PDO\TraceablePDO
{
    public function __call($name, array $arguments)
    {
        return call_user_func_array(array($this->pdo, $name), $arguments);
    }
}
```
