### PR TITLE
Fix open-btn css

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -96,7 +96,7 @@ a.phpdebugbar-close-btn {
   height: 16px;
 }
 
-a.phpdebugbar-open-btn,{
+a.phpdebugbar-open-btn {
   background: url(icons.png) no-repeat -14px 8px;
   width: 16px;
   height: 16px;


### PR DESCRIPTION
Whoops, trailing comma killed the open button.
