### PR TITLE
Trigger resize handler

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -764,6 +764,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             localStorage.setItem('phpdebugbar-open', '1');
             this.restoreState();
             this.$el.removeClass(csscls('closed'));
+            $(window).trigger('resize');
         },
 
         /**


### PR DESCRIPTION
Fixes #90, using the first proposed method.
Triggers the resizehandler after a restore, so the tabs are correctly responsive.
