### PR TITLE
Allow empty to address for SwiftMailer

### DIFF
--- a/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php
+++ b/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php
@@ -51,6 +51,8 @@ class SwiftMailCollector extends DataCollector implements Renderable
 
     protected function formatTo($to)
     {
+        if (!$to) return '';
+        
         $f = array();
         foreach ($to as $k => $v) {
             $f[] = (empty($v) ? '' : "$v ") . "<$k>";


### PR DESCRIPTION
SwiftMailer seems to work fine when sending mail without a To address and only BCC addresses. I used this when sending emails to a list of people where I didn't want any of them to see each other's addresses. The emails would go out fine but when using the debug bar it would create an error because the To address array was empty when formatting.
