### PR TITLE
Make isString configurable

### DIFF
--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -60,9 +60,8 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
      * @param mixed $message
      * @param string $label
      */
-    public function addMessage($message, $label = 'info')
+    public function addMessage($message, $label = 'info', $isString = true)
     {
-        $isString = true;
         if (!is_string($message)) {
             $message = $this->getDataFormatter()->formatVar($message);
             $isString = false;


### PR DESCRIPTION
The current `is_string` is really if it is a string, but rather that it should or shouldn't be prettified. With this tweak we can force the prettify behaviour (for example, multi-line logs or json_encode data is much more readable when prettified)
