### PR TITLE
Add title to variable keys

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -194,7 +194,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
         className: csscls('kvlist varlist'),
 
         itemRenderer: function(dt, dd, key, value) {
-            dt.text(key);
+            $('<span />').attr('title', key).text(key).appendTo(dt);
 
             var v = value;
             if (v && v.length > 100) {


### PR DESCRIPTION
So we can show them on hover.
Not the best solution, but at least an easy fix to show the truncated text.
