### PR TITLE
Add wrap to SQL code block  to make queries fully visible

### DIFF
--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.css
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.css
@@ -67,3 +67,8 @@ div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item span.phpdebu
   display: block;
   font-weight: bold;
 }
+code.phpdebugbar-widgets-sql {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
The CSS attributes of the `code` block surrounding SQL statements in the Database tab are inherited from the containing page. In some circumstances, this makes long queries unviewable if they extend past the width of the page. This change ensures that the SQL will wrap in the display if needed.
