### PR TITLE
Add LocalizationCollector

### DIFF
--- a/src/DebugBar/DataCollector/LocalizationCollector.php
+++ b/src/DebugBar/DataCollector/LocalizationCollector.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * This file is part of the DebugBar package.
+ *
+ * (c) 2013 Maxime Bouroumeau-Fuseau
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DebugBar\DataCollector;
+
+use Exception;
+
+/**
+ * Collects info about the current localization state
+ */
+class LocalizationCollector extends DataCollector implements Renderable
+{
+    /**
+     * Get the current locale
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return setlocale(LC_ALL, 0);
+    }
+
+    /**
+     * Get the current translations domain
+     *
+     * @return string
+     */
+    public function getDomain()
+    {
+        return textdomain();
+    }
+
+    public function collect()
+    {
+        return array(
+          'locale' => $this->getLocale(),
+          'domain' => $this->getDomain(),
+        );
+    }
+
+    public function getName()
+    {
+        return 'localization';
+    }
+
+    public function getWidgets()
+    {
+        return array(
+            'domain' => array(
+                'icon' => 'bookmark',
+                'map'  => 'localization.domain',
+            ),
+            'locale' => array(
+                'icon' => 'flag',
+                'map'  => 'localization.locale',
+            )
+        );
+    }
+}


### PR DESCRIPTION
This adds a Localization collector for working with multilingual projects. It displays the current locale and translation domain. I didn't add it to the default collector stack as I don't think it fits all projects but it's definitely a nice thing to have.
