### PR TITLE
Force convert to UTF-8

### DIFF
--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -214,6 +214,13 @@ class DebugBar implements ArrayAccess
         foreach ($this->collectors as $name => $collector) {
             $this->data[$name] = $collector->collect();
         }
+        
+        // Remove all invalid (non UTF-8) characters
+        array_walk_recursive($this->data, function(&$item){
+                if (is_string($item) && !mb_check_encoding($item, 'UTF-8')) {
+                    $item = mb_convert_encoding($item, 'UTF-8', 'UTF-8');
+                }
+            });
 
         if ($this->storage !== null) {
             $this->storage->save($this->getCurrentRequestId(), $this->data);


### PR DESCRIPTION
Not sure if this is the best/most efficient method and haven't really check the impact, but what do you think about this?
I keep running into edge cases when dealing with debugging non-utf8 data, this would make sure that all strings are utf8, or converted to utf-8 (with non-utf8 characters replaced)
Otherwise json_encode will throw an exception..
