### PR TITLE
force save data before shutdown

### DIFF
--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -465,4 +465,8 @@ class DebugBar implements ArrayAccess
     {
         throw new DebugBarException("DebugBar[] is read-only");
     }
+    public function __destruct()
+    {
+        $this->collect();
+    }
 }


### PR DESCRIPTION
fix bug some data (ex PDO activities) not save when use `die()` or `exit()` function to force end script
