### PR TITLE
Suggest 1.*, instead of >=1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ with the following requirement:
 ```JSON
 {
     "require": {
-        "maximebf/debugbar": ">=1.0.0"
+        "maximebf/debugbar": "1.*"
     }
 }
 ```


### PR DESCRIPTION
Probably breaking changes with 2.x right?
