### PR TITLE
Add branch-alias for 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
         "kriswallsmith/assetic": "The best way to manage assets",
         "monolog/monolog": "Log using Monolog",
         "predis/predis": "Redis storage"
+    },
+     "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
So people can require 1.x@dev or just 1.x when they set their minimum stability to dev, instead of having to require dev-master (which can conflict when other packages require 1.x)
