### PR TITLE
Update Font Awesome dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "maximebf/php-debugbar",
   "dependencies": {
     "jquery": "~1.*",
-    "font-awesome": "~4.0.3"
+    "font-awesome": "~4.1.0"
   }
 }


### PR DESCRIPTION
This is so that projects that contain the Font Awesome library themselves, and rely on some new icons, but also use the debug bar, can still see the new icons properly on their site.
