### PR TITLE
Restrict resizing to visible screen

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -461,6 +461,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
             // dragging of resize handle
             var dragging = false;
+            var min_h = 40;
+            var max_h = $(window).height() - this.$header.height() - 10;
             this.$resizehdle.on('mousedown', function(e) {
                 var orig_h = $body.height(), pos_y = e.pageY;
                 dragging = true;
@@ -468,6 +470,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 $body.parents().on('mousemove', function(e) {
                     if (dragging) {
                         var h = orig_h + (pos_y - e.pageY);
+                        // Respect the min/max values
+                        h = Math.min(h, max_h);
+                        h = Math.max(h, min_h);
                         $body.css('height', h);
                         localStorage.setItem('phpdebugbar-height', h);
                         self.recomputeBottomOffset();


### PR DESCRIPTION
This makes sure that the debugbar isn't dragged to high, so the handler is unreachable, and not too low to make sure it's always clear that it's just resized, not broken/collapsed.
See https://github.com/barryvdh/laravel-debugbar/issues/122, https://github.com/barryvdh/laravel-debugbar/issues/171 and https://github.com/barryvdh/laravel-debugbar/issues/16
