### PR TITLE
Fix regex for windows paths + uppercase protocols

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -595,7 +595,7 @@ class JavascriptRenderer
             return $uris;
         }
 
-        if (substr($uri, 0, 1) === '/' || preg_match('/^([a-z]+:\/\/|[a-zA-Z]:\/)/', $uri)) {
+        if (substr($uri, 0, 1) === '/' || preg_match('/^([a-zA-Z]+:\/\/|[a-zA-Z]:\/|[a-zA-Z]:\\\)/', $uri)) {
             return $uri;
         }
         return rtrim($root, '/') . "/$uri";


### PR DESCRIPTION
This also validates paths like `C:\sdf` instead of only `C:/sdf`. Also allows `HTTP://` instead of just `http://`
