### PR TITLE
Added missing params display and render blocks

### DIFF
--- a/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
+++ b/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
@@ -118,4 +118,9 @@ class TraceableTwigTemplate implements Twig_TemplateInterface
 
         return ob_get_clean();
     }
+
+    public static function clearCache()
+    {
+        $this->template->clearCache();
+    }
 }


### PR DESCRIPTION
Missing $useBlocks params in `displayBlock(`) and `renderBlock()` methods causing infinite loops in certain Twig rendering scenarios.
