### PR TITLE
Extend Template widget

### DIFF
--- a/src/DebugBar/Resources/widgets/templates/widget.css
+++ b/src/DebugBar/Resources/widgets/templates/widget.css
@@ -8,16 +8,53 @@ div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status {
   background: #fafafa;
 }
 
-div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-render_time {
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-render-time,
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-memory,
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count,
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-type {
   float: right;
+  margin-left: 8px;
+  color: #888;
 }
-div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-render_time:before {
-  content: "\f017";
-  font-family: FontAwesome;
-  font-size: 12px;
-  margin-right: 4px;
-}
-
-div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status span.phpdebugbar-widgets-render_time {
+div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status span.phpdebugbar-widgets-render-time,
+div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status span.phpdebugbar-widgets-memory,
+div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status span.phpdebugbar-widgets-param-count,
+div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status span.phpdebugbar-widgets-type {
   color: #555;
+}
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-render-time:before,
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-memory:before,
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count:before,
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-type:before {
+  font-family: FontAwesome;
+  margin-right: 4px;
+  font-size: 12px;
+}
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-render-time:before {
+  content: "\f017";
+}
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-memory:before {
+  content: "\f085";
+}
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count:before {
+  content: "\f0ce";
+}
+div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-type:before {
+  content: "\f121";
+}
+div.phpdebugbar-widgets-templates table.phpdebugbar-widgets-params {
+  display: none;
+  width: 70%;
+  margin: 10px;
+  border: 1px solid #ddd;
+  font-family: monospace;
+  border-collapse: collapse;
+}
+div.phpdebugbar-widgets-templates table.phpdebugbar-widgets-params td {
+  border: 1px solid #ddd;
+  text-align: left;
+}
+div.phpdebugbar-widgets-templates table.phpdebugbar-widgets-params .phpdebugbar-widgets-name {
+  width: 20%;
+  font-weight: bold;
 }

--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -18,17 +18,48 @@
             this.$list = new  PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, tpl) {
                 $('<span />').addClass(csscls('name')).text(tpl.name).appendTo(li);
                 if (tpl.render_time_str) {
-                    $('<span title="Render time" />').addClass(csscls('render_time')).text(tpl.render_time_str).appendTo(li);
+                    $('<span title="Render time" />').addClass(csscls('render-time')).text(tpl.render_time_str).appendTo(li);
+                }
+                if (tpl.memory_str) {
+                    $('<span title="Memory usage" />').addClass(csscls('memory')).text(tpl.memory_str).appendTo(li);
+                }
+                if (typeof(tpl.param_count) != 'undefined') {
+                    $('<span title="Parameter count" />').addClass(csscls('param-count')).text(tpl.param_count).appendTo(li);
+                }
+                if (typeof(tpl.type) != 'undefined') {
+                    $('<span title="Type" />').addClass(csscls('type')).text(tpl.type).appendTo(li);
+                }
+                if (tpl.params && !$.isEmptyObject(tpl.params)) {
+                    var table = $('<table><tr><th colspan="2">Params</th></tr></table>').addClass(csscls('params')).appendTo(li);
+                    for (var key in tpl.params) {
+                        if (typeof tpl.params[key] !== 'function') {
+                            table.append('<tr><td class="' + csscls('name') + '">' + key + '</td><td class="' + csscls('value') +
+                            '"><pre><code>' + tpl.params[key] + '</code></pre></td></tr>');
+                        }
+                    }
+                    li.css('cursor', 'pointer').click(function() {
+                        if (table.is(':visible')) {
+                            table.hide();
+                        } else {
+                            table.show();
+                        }
+                    });
                 }
             }});
             this.$list.$el.appendTo(this.$el);
 
             this.bindAttr('data', function(data) {
                 this.$list.set('data', data.templates);
+                this.$status.empty();
+
                 var sentence = data.sentence || "templates were rendered";
-                this.$status.empty().append($('<span />').text(data.templates.length + " " + sentence));
+                $('<span />').text(data.templates.length + " " + sentence).appendTo(this.$status);
+
                 if (data.accumulated_render_time_str) {
-                    this.$status.append($('<span title="Accumulated render time" />').addClass(csscls('render_time')).text(data.accumulated_render_time_str));
+                    this.$status.append($('<span title="Accumulated render time" />').addClass(csscls('render-time')).text(data.accumulated_render_time_str));
+                }
+                if (data.memory_usage_str) {
+                    this.$status.append($('<span title="Memory usage" />').addClass(csscls('memory')).text(data.memory_usage_str));
                 }
             });
         }


### PR DESCRIPTION
Based on SQL Queries widget, this adds param_count, memory_str, type and
expandable params, as proposed in #114
This shouldn't break anything, just add more information if supplied.

This makes it a bit more flexible. Not sure if param_count, memory and type are the correct ones (next to render_time), but I use params right now (duration/memory not yet). Type is for example to show if it's twig/blade/phtml etc.

@maximebf more suggestions to show?
