### PR TITLE
Using __call() for missing methods. Twig macro fix.

### DIFF
--- a/src/DebugBar/Bridge/Twig/TraceableTwigEnvironment.php
+++ b/src/DebugBar/Bridge/Twig/TraceableTwigEnvironment.php
@@ -43,6 +43,11 @@ class TraceableTwigEnvironment extends Twig_Environment
         $this->timeDataCollector = $timeDataCollector;
     }
 
+    public function __call($name, $arguments)
+    {
+        return call_user_func_array(array($this->twig, $name), $arguments);
+    }
+
     public function getRenderedTemplates()
     {
         return $this->renderedTemplates;

--- a/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
+++ b/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
@@ -30,6 +30,11 @@ class TraceableTwigTemplate implements Twig_TemplateInterface
         $this->template = $template;
     }
 
+    public function __call($name, $arguments)
+    {
+        return call_user_func_array(array($this->template, $name), $arguments);
+    }
+
     public function getTemplateName()
     {
         return $this->template->getTemplateName();


### PR DESCRIPTION
Regarding: https://github.com/maximebf/php-debugbar/issues/176
