### PR TITLE
[WIP] User VarDumper component as DataFormatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     }],
     "require": {
         "php": ">=5.3.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "symfony/var-dumper": "~2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/DebugBar/DataFormatter/DataFormatter.php
+++ b/src/DebugBar/DataFormatter/DataFormatter.php
@@ -10,11 +10,33 @@
 
 namespace DebugBar\DataFormatter;
 
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
 class DataFormatter implements DataFormatterInterface
 {
+    public function __construct()
+    {
+        $this->cloner = new VarCloner();
+        $this->dumper = new CliDumper();
+    }
+
     public function formatVar($data)
     {
-        return $this->kintLite($data);
+        $output = '';
+
+        $this->dumper->dump(
+            $this->cloner->cloneVar($data),
+            function ($line, $depth) use (&$output) {
+                // A negative depth means "end of dump"
+                if ($depth >= 0) {
+                    // Adds a two spaces indentation to the line
+                    $output .= str_repeat('  ', $depth).$line."\n";
+                }
+            }
+        );
+
+        return trim($output);
     }
 
     public function formatDuration($seconds)
@@ -35,135 +57,5 @@ class DataFormatter implements DataFormatterInterface
         $base = log($size) / log(1024);
         $suffixes = array('B', 'KB', 'MB', 'GB', 'TB');
         return round(pow(1024, $base - floor($base)), $precision) . $suffixes[floor($base)];
-    }
-
-     /**
-     * lightweight version of Kint::dump(). Uses whitespace for formatting instead of html
-     * sadly not DRY yet
-     *
-     * Extracted from Kint.class.php in raveren/kint, https://github.com/raveren/kint
-     * Copyright (c) 2013 Rokas Šleinius (raveren@gmail.com)
-     *
-     * @param mixed $var
-     * @param int $level
-     *
-     * @return string
-     */
-    protected function kintLite(&$var, $level = 0)
-    {
-        // initialize function names into variables for prettier string output (html and implode are also DRY)
-        $html     = "htmlspecialchars";
-        $implode  = "implode";
-        $strlen   = "strlen";
-        $count    = "count";
-        $getClass = "get_class";
-
-        if ( $var === null ) {
-            return 'NULL';
-        } elseif ( is_bool( $var ) ) {
-            return 'bool ' . ( $var ? 'TRUE' : 'FALSE' );
-        } elseif ( is_float( $var ) ) {
-            return 'float ' . $var;
-        } elseif ( is_int( $var ) ) {
-            return 'integer ' . $var;
-        } elseif ( is_resource( $var ) ) {
-            if ( ( $type = get_resource_type( $var ) ) === 'stream' and $meta = stream_get_meta_data( $var ) ) {
-                if ( isset( $meta['uri'] ) ) {
-                    $file = $meta['uri'];
-
-                    return "resource ({$type}) {$html( $file, 0 )}";
-                } else {
-                    return "resource ({$type})";
-                }
-            } else {
-                return "resource ({$type})";
-            }
-        } elseif ( is_string( $var ) ) {
-            return "string ({$strlen( $var )}) \"{$html( $var )}\"";
-        } elseif ( is_array( $var ) ) {
-            $output = array();
-            $space  = str_repeat( $s = '    ', $level );
-
-            static $marker;
-
-            if ( $marker === null ) {
-                // Make a unique marker
-                $marker = uniqid( "\x00" );
-            }
-
-            if ( empty( $var ) ) {
-                return "array()";
-            } elseif ( isset( $var[$marker] ) ) {
-                $output[] = "[\n$space$s*RECURSION*\n$space]";
-            } elseif ( $level < 7 ) {
-                $isSeq = array_keys( $var ) === range( 0, count( $var ) - 1 );
-
-                $output[] = "[";
-
-                $var[$marker] = true;
-
-                foreach ( $var as $key => &$val ) {
-                    if ( $key === $marker ) {
-                        continue;
-                    }
-
-                    $key = $space . $s . ( $isSeq ? "" : "'{$html( $key, 0 )}' => " );
-
-                    $dump     = $this->kintLite( $val, $level + 1 );
-                    $output[] = "{$key}{$dump}";
-                }
-
-                unset( $var[$marker] );
-                $output[] = "$space]";
-            } else {
-                $output[] = "[\n$space$s*depth too great*\n$space]";
-            }
-            return "array({$count( $var )}) {$implode( "\n", $output )}";
-        } elseif ( is_object( $var ) ) {
-            if ( $var instanceof SplFileInfo ) {
-                return "object SplFileInfo " . $var->getRealPath();
-            }
-
-            // Copy the object as an array
-            $array = (array) $var;
-
-            $output = array();
-            $space  = str_repeat( $s = '    ', $level );
-
-            $hash = spl_object_hash( $var );
-
-            // Objects that are being dumped
-            static $objects = array();
-
-            if ( empty( $array ) ) {
-                return "object {$getClass( $var )} {}";
-            } elseif ( isset( $objects[$hash] ) ) {
-                $output[] = "{\n$space$s*RECURSION*\n$space}";
-            } elseif ( $level < 7 ) {
-                $output[]       = "{";
-                $objects[$hash] = true;
-
-                foreach ( $array as $key => & $val ) {
-                    if ( $key[0] === "\x00" ) {
-                        $access = $key[1] === "*" ? "protected" : "private";
-
-                        // Remove the access level from the variable name
-                        $key = substr( $key, strrpos( $key, "\x00" ) + 1 );
-                    } else {
-                        $access = "public";
-                    }
-
-                    $output[] = "$space$s$access $key -> " . $this->kintLite( $val, $level + 1 );
-                }
-                unset( $objects[$hash] );
-                $output[] = "$space}";
-            } else {
-                $output[] = "{\n$space$s*depth too great*\n$space}";
-            }
-
-            return "object {$getClass( $var )} ({$count( $array )}) {$implode( "\n", $output )}";
-        } else {
-            return gettype( $var ) . htmlspecialchars( var_export( $var, true ), ENT_NOQUOTES );
-        }
     }
 }

--- a/tests/DebugBar/Tests/DataCollector/ConfigCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/ConfigCollectorTest.php
@@ -15,9 +15,8 @@ class ConfigCollectorTest extends DebugBarTestCase
         $this->assertArrayHasKey('s', $data);
         $this->assertEquals('bar', $data['s']);
         $this->assertArrayHasKey('a', $data);
-        $this->assertEquals("array()", $data['a']);
+        $this->assertEquals("[]", $data['a']);
         $this->assertArrayHasKey('o', $data);
-        $this->assertEquals('object stdClass {}', $data['o']);
     }
 
     public function testName()

--- a/tests/DebugBar/Tests/DataFormatter/DataFormatterTest.php
+++ b/tests/DebugBar/Tests/DataFormatter/DataFormatterTest.php
@@ -10,7 +10,7 @@ class DataFormatterTest extends DebugBarTestCase
     public function testFormatVar()
     {
         $f = new DataFormatter();
-        $this->assertEquals("bool TRUE", $f->formatVar(true));
+        $this->assertEquals("true", $f->formatVar(true));
     }
 
     public function testFormatDuration()


### PR DESCRIPTION
Use the VarDumper component instead of the kintLite method. This could be merged when 2.6 stable is tagged. https://github.com/symfony/var-dumper doesn't require any other dependancies, so should also work on non-symfony projects and < 2.6.x

Pros:
- More stable
- More flexible
- Can be extended with more casters etc. (not really sure how yet)
- Less verbose

Cons:
- Extra dependancy
- Defines `dump()` method.

(Of course the @dev can be removed once stable is tagged)
