### PR TITLE
Allow disabling of specific vendor assets

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -37,13 +37,13 @@ class JavascriptRenderer
     protected $basePath;
 
     protected $cssVendors = array(
-        'vendor/font-awesome/css/font-awesome.min.css',
-        'vendor/highlightjs/styles/github.css'
+        'fontawesome' => 'vendor/font-awesome/css/font-awesome.min.css',
+        'highlightjs' => 'vendor/highlightjs/styles/github.css'
     );
 
     protected $jsVendors = array(
-        'vendor/jquery/dist/jquery.min.js',
-        'vendor/highlightjs/highlight.pack.js'
+        'jquery' => 'vendor/jquery/dist/jquery.min.js',
+        'highlightjs' => 'vendor/highlightjs/highlight.pack.js'
     );
 
     protected $includeVendors = true;
@@ -245,6 +245,23 @@ class JavascriptRenderer
     public function areVendorsIncluded()
     {
         return $this->includeVendors !== false;
+    }
+
+    /**
+     * Disable a specific vendor's assets.
+     *
+     * @param  string $name "jquery", "fontawesome", "highlightjs"
+     *
+     * @return void
+     */
+    public function disableVendor($name)
+    {
+        if (array_key_exists($name, $this->cssVendors)) {
+            unset($this->cssVendors[$name]);
+        }
+        if (array_key_exists($name, $this->jsVendors)) {
+            unset($this->jsVendors[$name]);
+        }
     }
 
     /**

--- a/tests/DebugBar/Tests/JavascriptRendererTest.php
+++ b/tests/DebugBar/Tests/JavascriptRendererTest.php
@@ -126,4 +126,11 @@ class JavascriptRendererTest extends DebugBarTestCase
         $this->r->setIncludeVendors(array('css', 'js'));
         $this->assertTrue($this->r->isJqueryNoConflictEnabled());
     }
+
+    public function testCanDisableSpecificVendors()
+    {
+        $this->assertContains('jquery.min.js', $this->r->renderHead());
+        $this->r->disableVendor('jquery');
+        $this->assertNotContains('jquery.min.js', $this->r->renderHead());
+    }
 }


### PR DESCRIPTION
I spent way too long debugging why some FontAwesome icons weren't showing up, and it turned out that DebugBar's FontAwesome CSS was being loaded before mine. I ended up having to override both the DebugBar _and_ JavascriptRenderer classes and override the protected property `$cssVendors` to get rid of DebugBar's FontAwesome CSS entirely. This patch makes it possible to more easily disable specific vendors.

``` php
$debugBar->getJavascriptRenderer()->disableVendor('fontawesome');
$debugBar->getJavascriptRenderer()->disableVendor('highlightjs');
$debugBar->getJavascriptRenderer()->disableVendor('jquery');
```
