### PR TITLE
Bar drag fix for iframes, window size changes and bar restore

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -12,6 +12,18 @@ div.phpdebugbar {
   text-align: left;
 }
 
+div.phpdebugbar-drag-capture {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10001;
+  background: none;
+  display: none;
+  cursor: n-resize;
+}
+
 div.phpdebugbar-closed {
     width: auto;
 }


### PR DESCRIPTION
# Overview

This commit fixes a few bugs with changing the height of the debugbar by dragging, resizing the browser window or through restoreState.
## IFrames

IFrames in the window being debugged prevent the dragging of the resize handle as they consume the mousemove and mousup events

Fixed by displaying a div (class phpdebugbar-drag-capture) over the whole window when dragging and hiding it when finished, ensuring that all events are visible to the window. 
## Multiple mouse handler registrations

Mousemove/mouseup handlers are registered every time the mouse is pressed on the resize handle but old ones are never removed, with the result that multiple handlers can be registered.

Fixed by removing event handlers on mouseup.
## Misc bar height issues

When the height of the bar is set it should be restricted so it does not disappear off the top of the browser window, the value saved in local storage and the body bottom offset recalculated.  These actions are not all performed on window resize or bar restoreState.

Extracted bar height logic into a new function, setHeight, which is called from windows resize, bar restoreState and the mousemove handler.
