### PR TITLE
Show the real parameter name for prepared queries.

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -132,8 +132,8 @@ class TracedStatement
     public function getParameters()
     {
         $params = array();
-        foreach ($this->parameters as $param) {
-            $params[] = htmlentities($param, ENT_QUOTES, 'UTF-8', false);
+        foreach ($this->parameters as $name => $param) {
+            $params[$name] = htmlentities($param, ENT_QUOTES, 'UTF-8', false);
         }
         return $params;
     }


### PR DESCRIPTION
Array index works only with positioned (where foo = ?) parameters.
To make named (where foo = :baz) parameters debuggable the name must be defined as key.