### PR TITLE
baseUrl calculated from DOCUMENT_ROOT

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -86,7 +86,12 @@ class JavascriptRenderer
         $this->debugBar = $debugBar;
 
         if ($baseUrl === null) {
-            $baseUrl = '/vendor/maximebf/debugbar/src/DebugBar/Resources';
+            //calculate $baseUrl from docroot should the docroot exist in the $_SERVER global
+			if( array_key_exists('DOCUMENT_ROOT',$_SERVER) ){
+				$baseUrl = str_replace($_SERVER['DOCUMENT_ROOT'], '', __DIR__ .'/Resources');
+			} else {
+				$baseUrl = '/vendor/maximebf/debugbar/src/DebugBar/Resources';
+			}
         }
         $this->baseUrl = $baseUrl;
 


### PR DESCRIPTION
Composer files are not always in the root of the docroot in some projects. Should the DOCUMENT_ROOT not be available it reverts to the hard coded path. This method I find quicker than having to declare the path when calling the DebugBar in new projects, or when the composer is updated.