### PR TITLE
Add a div at the end of body for a bottom offset

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -463,6 +463,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.$headerLeft = $('<div />').addClass(csscls('header-left')).appendTo(this.$header);
             this.$headerRight = $('<div />').addClass(csscls('header-right')).appendTo(this.$header);
             var $body = this.$body = $('<div />').addClass(csscls('body')).appendTo(this.$el);
+            this.$paddingBottom = $('<div />').addClass(csscls('padding-bottom')).appendTo('body');
             this.recomputeBottomOffset();
 
             // dragging of resize handle
@@ -817,7 +818,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
          */
         recomputeBottomOffset: function() {
             if (this.options.bodyPaddingBottom) {
-                $('body').css('padding-bottom', this.$el.height());
+                this.$paddingBottom.height(this.$el.height());
             }
         },
 


### PR DESCRIPTION
Adding CSS padding-bottom to the body element does not work in some cases  (body height set to 100% fills the viewport and content overflows right through the padding)

This solution adds a div after the debugbar and recomputeBottomOffset is modified to set the height of this div to the height of the debugbar.
