### PR TITLE
Improve accuracy of Timeline

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -367,8 +367,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         var measure = data.measures[i];
                         var m = $('<div />').addClass(csscls('measure')),
                             li = $('<li />'),
-                            left = Math.round(measure.relative_start * 100 / data.duration),
-                            width = Math.min(Math.round(measure.duration * 100 / data.duration), 100 - left);
+                            left = (measure.relative_start * 100 / data.duration).toFixed(2),
+                            width = Math.min((measure.duration * 100 / data.duration).toFixed(2), 100 - left);
 
                         m.append($('<span />').addClass(csscls('value')).css({
                             left: left + "%",


### PR DESCRIPTION
Don't round left/width, instead use two decimals.

This improves accuracy of Timeline when more similar sized entries are shown.