### PR TITLE
Hiding PHPDebugBar on @media print

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -1,3 +1,10 @@
+/* Hide debugbar when printing a page */
+@media print {
+  div.phpdebugbar {
+    display: none;
+  }
+}
+
 div.phpdebugbar {
   position: fixed;
   bottom: 0;


### PR DESCRIPTION
PHPDebugBar showing in `@media print` makes no sense as it's purpose is debug.
This makes easier to test printing pages on debug server.