### PR TITLE
Remove meaningless hrefs

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -20,7 +20,8 @@ div.phpdebugbar {
   line-height: 1;
 }
 
-div.phpdebugbar a {
+div.phpdebugbar a,
+div.phpdebugbar-openhandler {
   cursor: pointer;
 }
 

--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -20,6 +20,10 @@ div.phpdebugbar {
   line-height: 1;
 }
 
+div.phpdebugbar a {
+  cursor: pointer;
+}
+
 div.phpdebugbar-drag-capture {
   position: fixed;
   top: 0;

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -255,7 +255,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
         className: csscls('panel'),
 
         render: function() {
-            this.$tab = $('<a href="javascript:" />').addClass(csscls('tab'));
+            this.$tab = $('<a />').addClass(csscls('tab'));
 
             this.$icon = $('<i />').appendTo(this.$tab);
             this.bindAttr('icon', function(icon) {
@@ -483,31 +483,31 @@ if (typeof(PhpDebugBar) == 'undefined') {
             };
 
             // close button
-            this.$closebtn = $('<a href="javascript:" />').addClass(csscls('close-btn')).appendTo(this.$headerRight);
+            this.$closebtn = $('<a />').addClass(csscls('close-btn')).appendTo(this.$headerRight);
             this.$closebtn.click(function() {
                 self.close();
             });
 
             // minimize button
-            this.$minimizebtn = $('<a href="javascript:" />').addClass(csscls('minimize-btn') ).appendTo(this.$headerRight);
+            this.$minimizebtn = $('<a />').addClass(csscls('minimize-btn') ).appendTo(this.$headerRight);
             this.$minimizebtn.click(function() {
                 self.minimize();
             });
 
             // maximize button
-            this.$maximizebtn = $('<a href="javascript:" />').addClass(csscls('maximize-btn') ).appendTo(this.$headerRight);
+            this.$maximizebtn = $('<a />').addClass(csscls('maximize-btn') ).appendTo(this.$headerRight);
             this.$maximizebtn.click(function() {
                 self.restore();
             });
 
             // restore button
-            this.$restorebtn = $('<a href="javascript:" />').addClass(csscls('restore-btn')).hide().appendTo(this.$el);
+            this.$restorebtn = $('<a />').addClass(csscls('restore-btn')).hide().appendTo(this.$el);
             this.$restorebtn.click(function() {
                 self.restore();
             });
 
             // open button
-            this.$openbtn = $('<a href="javascript:" />').addClass(csscls('open-btn')).appendTo(this.$headerRight).hide();
+            this.$openbtn = $('<a />').addClass(csscls('open-btn')).appendTo(this.$headerRight).hide();
             this.$openbtn.click(function() {
                 self.openHandler.show(function(id, dataset) {
                     self.addDataSet(dataset, id, "(opened)");

--- a/src/DebugBar/Resources/openhandler.js
+++ b/src/DebugBar/Resources/openhandler.js
@@ -22,7 +22,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             var self = this;
             
             this.$el.appendTo('body').hide();
-            this.$closebtn = $('<a href="javascript:"><i class="fa fa-times"></i></a>');
+            this.$closebtn = $('<a><i class="fa fa-times"></i></a>');
             this.$table = $('<tbody />');
             $('<div>PHP DebugBar | Open</div>').addClass(csscls('header')).append(this.$closebtn).appendTo(this.$el);
             $('<table><thead><tr><th width="150">Date</th><th width="55">Method</th><th>URL</th><th width="125">IP</th><th width="100">Filter data</th></tr></thead></table>').append(this.$table).appendTo(this.$el);
@@ -32,26 +32,26 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 self.hide();
             });
 
-            this.$loadmorebtn = $('<a href="javascript:">Load more</a>')
+            this.$loadmorebtn = $('<a>Load more</a>')
                 .appendTo(this.$actions)
                 .on('click', function() {
                     self.find(self.last_find_request, self.last_find_request.offset + self.get('items_per_page'), self.handleFind.bind(self));
                 });
 
-            this.$showonlycurrentbtn = $('<a href="javascript:">Show only current URL</a>')
+            this.$showonlycurrentbtn = $('<a>Show only current URL</a>')
                 .appendTo(this.$actions)
                 .on('click', function() {
                     self.$table.empty();
                     self.find({uri: window.location.pathname}, 0, self.handleFind.bind(self));
                 });
 
-            this.$showallbtn = $('<a href="javascript:">Show all</a>')
+            this.$showallbtn = $('<a>Show all</a>')
                 .appendTo(this.$actions)
                 .on('click', function() {
                     self.refresh();
                 });
 
-            this.$clearbtn = $('<a href="javascript:">Delete all</a>')
+            this.$clearbtn = $('<a>Delete all</a>')
                 .appendTo(this.$actions)
                 .on('click', function() {
                     self.clear(function() {
@@ -104,7 +104,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
         handleFind: function(data) {
             var self = this;
             $.each(data, function(i, meta) {
-               var a = $('<a href="javascript:" />')
+               var a = $('<a />')
                     .text('Load dataset')
                     .on('click', function(e) {
                        self.hide();
@@ -114,7 +114,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                        e.preventDefault();
                     });
                     
-                var method = $('<a href="javascript:" />')
+                var method = $('<a />')
                     .text(meta['method'])
                     .on('click', function(e) {
                         self.$table.empty();
@@ -122,7 +122,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         e.preventDefault();
                     });
 
-                var uri = $('<a href="javascript:" />')
+                var uri = $('<a />')
                     .text(meta['uri'])
                     .on('click', function(e) {
                         self.hide();
@@ -132,7 +132,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         e.preventDefault();
                     });
 
-                var ip = $('<a href="javascript:" />')
+                var ip = $('<a />')
                     .text(meta['ip'])
                     .on('click', function(e) {
                         self.$table.empty();
@@ -140,7 +140,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         e.preventDefault();
                     });
 
-                var search = $('<a href="javascript:" />')
+                var search = $('<a />')
                     .text('Show URL')
                     .on('click', function(e) {
                         self.$table.empty();

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -307,7 +307,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         continue;
                     }
                     filters.push(data[i].label);
-                    $('<a href="javascript:" />')
+                    $('<a />')
                         .addClass(csscls('filter'))
                         .text(data[i].label)
                         .attr('rel', data[i].label)

--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.js
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.js
@@ -54,7 +54,7 @@
                     li.attr("connection",stmt.connection);
                     if ( $.inArray(stmt.connection, filters) == -1 ) {
                         filters.push(stmt.connection);
-                        $('<a href="javascript:" />')
+                        $('<a />')
                             .addClass(csscls('filter'))
                             .text(stmt.connection)
                             .attr('rel', stmt.connection)


### PR DESCRIPTION
Links have `href` attribute set to `javascript:`, which is not only useless, but unnecessarily shows destination on hover. It's annoying for debugbar, because it takes some place on the screen when we just hover on any tab. HTML5 specification allows anchors with no `href` specified, as mentioned here: http://w3c.github.io/html-reference/a.html#a.attrs.href

The only difference is that they then get standard cursor by default, which is corrected as well by my pull merge.