### PR TITLE
Enable caseless searching in the "Files" toolbar

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -318,12 +318,12 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
             this.bindAttr(['exclude', 'search'], function() {
                 var data = this.get('data'),
-                    exclude = this.get('exclude'), 
-                    search = this.get('search'),
+                    exclude = this.get('exclude'),
+                    search = this.get('search').toLowerCase(),
                     fdata = [];
 
                 for (var i = 0; i < data.length; i++) {
-                    if ((!data[i].label || $.inArray(data[i].label, exclude) === -1) && (!search || data[i].message.indexOf(search) > -1)) {
+                    if ((!data[i].label || $.inArray(data[i].label, exclude) === -1) && (!search || data[i].message.toLowerCase().indexOf(search) > -1)) {
                         fdata.push(data[i]);
                     }
                 }

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -319,11 +319,18 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.bindAttr(['exclude', 'search'], function() {
                 var data = this.get('data'),
                     exclude = this.get('exclude'),
-                    search = this.get('search').toLowerCase(),
+                    search = this.get('search'),
+                    caseless = false,
                     fdata = [];
 
+                if (search && search === search.toLowerCase()) {
+                    caseless = true;
+                }
+
                 for (var i = 0; i < data.length; i++) {
-                    if ((!data[i].label || $.inArray(data[i].label, exclude) === -1) && (!search || data[i].message.toLowerCase().indexOf(search) > -1)) {
+                    var message = caseless ? data[i].message.toLowerCase() : data[i].message;
+
+                    if ((!data[i].label || $.inArray(data[i].label, exclude) === -1) && (!search || message.indexOf(search) > -1)) {
                         fdata.push(data[i]);
                     }
                 }


### PR DESCRIPTION
Most of the time I want to see if a file was loaded and I don't really want to bother getting all of the camelCasing when I'm just doing a simple search.

This enables caseless matching in the files collector tab!

However, if caseless searching returns too many results, you can still search with Capitals and get a more narrowed set of results :smile: 

Closes #194.