### PR TITLE
Fix for wrong namespace lookup. No clean use possible otherwise.

### DIFF
--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -38,7 +38,7 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
      *
      * @param DataFormatterInterface $formater
      */
-    public function setDataFormatter(DataFormatterInterface $formater)
+    public function setDataFormatter(\DebugBar\DataFormatter\DataFormatterInterface $formater)
     {
         $this->dataFormater = $formater;
         return $this;

--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -11,6 +11,7 @@
 namespace DebugBar\DataCollector;
 
 use Psr\Log\AbstractLogger;
+use DebugBar\DataFormatter\DataFormatterInterface;
 
 /**
  * Provides a way to log messages
@@ -38,7 +39,7 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
      *
      * @param DataFormatterInterface $formater
      */
-    public function setDataFormatter(\DebugBar\DataFormatter\DataFormatterInterface $formater)
+    public function setDataFormatter(DataFormatterInterface $formater)
     {
         $this->dataFormater = $formater;
         return $this;


### PR DESCRIPTION
This fixes a bug - when extending the DataFormatter its not possible to set the new class as data formatter via collectorInstance->setDataFormatter(...) - it complains about wrong Interface.