### PR TITLE
Apply normal letter-spacing

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -18,6 +18,7 @@ div.phpdebugbar {
   color: #000;
   text-align: left;
   line-height: 1;
+  letter-spacing: normal;
 }
 
 div.phpdebugbar a,


### PR DESCRIPTION
I'm using debugbar on a website which has a very generous letter-spacing on the `body` element.
Unfortunately that cascades into the debugbar styling, which makes the data very difficult to read.

That being said, the `letter-spacing: normal;` resets the debugbar back to the intended result.