### PR TITLE
Added PHP_SAPI in Php data collector

### DIFF
--- a/src/DebugBar/DataCollector/PhpInfoCollector.php
+++ b/src/DebugBar/DataCollector/PhpInfoCollector.php
@@ -18,7 +18,8 @@ class PhpInfoCollector extends DataCollector
     public function collect()
     {
         return array(
-            'version' => PHP_VERSION
+            'version' => PHP_VERSION,
+            'interface' => PHP_SAPI
         );
     }
 


### PR DESCRIPTION
It is important to know how the php is running from cli or a web request. In some frameworks like laravel there is commands features which we also want to know the exception from command line or a web interface.