### PR TITLE
Added support for negative numbers in DataFormatter::formatBytes()

### DIFF
--- a/src/DebugBar/DataFormatter/DataFormatter.php
+++ b/src/DebugBar/DataFormatter/DataFormatter.php
@@ -54,8 +54,12 @@ class DataFormatter implements DataFormatterInterface
         if ($size === 0 || $size === null) {
             return "0B";
         }
+
+        $sign = $size < 0 ? '-' : '';
+        $size = abs($size);
+
         $base = log($size) / log(1024);
         $suffixes = array('B', 'KB', 'MB', 'GB', 'TB');
-        return round(pow(1024, $base - floor($base)), $precision) . $suffixes[floor($base)];
+        return $sign . round(pow(1024, $base - floor($base)), $precision) . $suffixes[floor($base)];
     }
 }

--- a/tests/DebugBar/Tests/DataFormatter/DataFormatterTest.php
+++ b/tests/DebugBar/Tests/DataFormatter/DataFormatterTest.php
@@ -29,5 +29,8 @@ class DataFormatterTest extends DebugBarTestCase
         $this->assertEquals("1B", $f->formatBytes(1));
         $this->assertEquals("1KB", $f->formatBytes(1024));
         $this->assertEquals("1MB", $f->formatBytes(1024 * 1024));
+        $this->assertEquals("-1B", $f->formatBytes(-1));
+        $this->assertEquals("-1KB", $f->formatBytes(-1024));
+        $this->assertEquals("-1MB", $f->formatBytes(-1024 * 1024));
     }
 }


### PR DESCRIPTION
It's possible for a `TracedStatement` to have a negative memory delta, which causes the DataFormatter to crash.