### PR TITLE
Offset calculation change to body margin-bottom

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -395,8 +395,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
         className: "phpdebugbar " + csscls('minimized'),
 
         options: {
-            bodyPaddingBottom: true,
-            bodyPaddingBottomHeight: parseInt($('body').css('padding-bottom'))
+            bodyMarginBottom: true,
+            bodyMarginBottomHeight: parseInt($('body').css('margin-bottom'))
         },
 
         initialize: function() {
@@ -813,13 +813,13 @@ if (typeof(PhpDebugBar) == 'undefined') {
         },
 
         /**
-         * Recomputes the padding-bottom css property of the body so
+         * Recomputes the margin-bottom css property of the body so
          * that the debug bar never hides any content
          */
         recomputeBottomOffset: function() {
-            if (this.options.bodyPaddingBottom) {
-                var height = parseInt(this.$el.height()) + this.options.bodyPaddingBottomHeight;
-                $('body').css('padding-bottom', height);
+            if (this.options.bodyMarginBottom) {
+                var height = parseInt(this.$el.height()) + this.options.bodyMarginBottomHeight;
+                $('body').css('margin-bottom', height);
             }
         },
 

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -793,7 +793,16 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.$el.addClass(csscls('closed'));
             this.recomputeBottomOffset();
         },
-
+        
+        /**
+         * Checks if the panel is closed
+         *
+         * @return {Boolean}
+         */
+        isClosed: function() {
+            return this.$el.hasClass(csscls('closed'));
+        },
+        
         /**
          * Restore the debug bar
          *
@@ -818,8 +827,12 @@ if (typeof(PhpDebugBar) == 'undefined') {
          */
         recomputeBottomOffset: function() {
             if (this.options.bodyMarginBottom) {
-                var height = parseInt(this.$el.height()) + this.options.bodyMarginBottomHeight;
-                $('body').css('margin-bottom', height);
+                if (this.isMinimized() || this.isClosed()) {
+                    return $('body').css('margin-bottom', this.options.bodyMarginBottomHeight || '');
+                }
+                
+                var offset = parseInt(this.$el.height()) + this.options.bodyMarginBottomHeight;
+                $('body').css('margin-bottom', offset);
             }
         },
 


### PR DESCRIPTION
Hello,
this PR fixes problems related to sites that use an absolute footers. In order to better get the idea here are some tests I have made:

http://debugbar.padding.codewizz.com/ - this one is using the old padding-bottom inline style (just try to expand the debugbar, you will see the footer starts to shrink and finally hides under the debugbar panel)
http://debugbar.margin.codewizz.com/ - this one is using the new margin-bottom inline style (at first it looks like the footer is being overlapped but you can scroll down and see all the web content like it should be displayed).

In addition I have added margin-bottom style removal from body once debugbar is closed or minimized. This is especially handy when your front-ender is working on a site and you don't want to toggle debugbar on and off so he could see the webpage like it should be displayed (it was a huge problem before when debugbar was using padding-bottom inline style on a body tag).

I hope this helps!

Looking forward.