### PR TITLE
fixed XSS vulnerability in sql parameter value rendering

### DIFF
--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.js
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.js
@@ -1,7 +1,25 @@
 (function($) {
 
     var csscls = PhpDebugBar.utils.makecsscls('phpdebugbar-widgets-');
+    
+    var entityMap = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+        '/': '&#x2F;',
+        '`': '&#x60;',
+        '=': '&#x3D;'
+    };
 
+    function escapeHtml (string) {
+      return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap (s) {
+        return entityMap[s];
+      });
+    }
+
+    
     /**
      * Widget for the displaying sql queries
      *
@@ -71,8 +89,8 @@
                     var table = $('<table><tr><th colspan="2">Params</th></tr></table>').addClass(csscls('params')).appendTo(li);
                     for (var key in stmt.params) {
                         if (typeof stmt.params[key] !== 'function') {
-                            table.append('<tr><td class="' + csscls('name') + '">' + key + '</td><td class="' + csscls('value') +
-                            '">' + stmt.params[key] + '</td></tr>');
+                            table.append('<tr><td class="' + csscls('name') + '">' + escapeHtml(key) + '</td><td class="' + csscls('value') +
+                            '">' + escapeHtml(stmt.params[key]) + '</td></tr>');
                         }
                     }
                     li.css('cursor', 'pointer').click(function() {


### PR DESCRIPTION
We found a security issue in the javascript part of sql sqlqueries widget: 
The values of parameters are rendered in a html table without any escaping, which makes it possible to do an XSS attack.

One might say, the debugbar is not intended to be used in production. Even if you ignore the security aspect of this issue, we might have rendering errors, if the params have any html in them. 

What i did to test:
`$entityManager->createQuery("select a from \My\Model\Comments a where a.kommentar=:c")->setParameter("c", "<script>alert();</script>")->execute();` 

We are using doctrine in our project. This resulted in mysql query with one parameter. The value of the parameter in debugbar appeared to be empty. Instead i saw the javascript alert.

Easy to fix with an escaping function. 
