### PR TITLE
Fix PDO erroroInfo() erasure

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -174,9 +174,10 @@ a.phpdebugbar-tab.phpdebugbar-active {
     color: white;
   }
 
-a.phpdebugbar-close-btn, a.phpdebugbar-open-btn, a.phpdebugbar-restore-btn, a.phpdebugbar-minimize-btn , a.phpdebugbar-maximize-btn {
+a.phpdebugbar-close-btn, a.phpdebugbar-open-btn, a.phpdebugbar-restore-btn, a.phpdebugbar-minimize-btn, a.phpdebugbar-maximize-btn {
   width: 16px;
   height: 16px;
+  text-align: center;
 }
 
 a.phpdebugbar-minimize-btn , a.phpdebugbar-maximize-btn {
@@ -190,22 +191,6 @@ a.phpdebugbar-minimize-btn { display: block}
 div.phpdebugbar-minimized a.phpdebugbar-maximize-btn { display: block}
 
 div.phpdebugbar-minimized a.phpdebugbar-minimize-btn { display: none}
-
-a.phpdebugbar-minimize-btn {
-  background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAZklEQVR4nM3OMQ4CIRAF0HcFVyvXErl/6VWM7eo11gYSQiBC5f5mksl/meFfCXggznSueGNPs4UDttT5YIUznmnZwvcC7XjhUl5t4Vh8k9GtfqeFf6IeHkI9PIRqPIVyTlhm0QHzBSfMK4g2snfEAAAAAElFTkSuQmCC)  no-repeat 6px 6px;
-}
-
-a.phpdebugbar-maximize-btn {
-  background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAZklEQVR4nM3OsQmAMBCF4Z+kcA13sUxhq9sZcAHBLVzIIqBNAuG4aNLlwVXvvuOglxhgbEUW2IEbcK3oiVOFJarCEgXg+sMaWoABOL/wJtCadRqeUnkUkIYDMOeFj++Vkna0w73nBRurK28mVdKbAAAAAElFTkSuQmCC)  no-repeat 6px 6px;
-}
-
-a.phpdebugbar-close-btn {
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuM4zml1AAAADDSURBVDhPxZCxCsIwFEUzuGdwCvQD7BIIcehUXDqVfGM/wsG/iG4ifkzMlRuSPLo4eeFBue8c6Iv6b4wxW557Hs0KnWa3seqDxTiOyVqbhmF4UND4Rofdruyce3rvE6bIRSo9GOI1McbLPM/vVm4l7MAQr0kpHaQsJTDE+6zrepym6SVFdNgR69M+hBTLzWCI10gJvydvBkO8ZlmWayvhJnkzGOI1+fBTCOHWPkT7YNiBId4HizxnCKy+r81uX/otSn0A7dioI/vYX+8AAAAASUVORK5CYII=) no-repeat 9px 6px;
-}
-
-a.phpdebugbar-open-btn {
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAOCAYAAADJ7fe0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAAHdElNRQfdCgYULwwNKp3GAAAAGHRFWHRTb2Z0d2FyZQBwYWludC5uZXQgNC4wLjOM5pdQAAAA1UlEQVQ4T2OgKpCUlOQH4vdA/B8Jv4dKEwYgDdLS0v8NDQ3/GxsbwzGIj2YoGEO1oQJkjcRgqDZUAJKwsrJ6/v//fwdiMFQbKgAZkpGR0QR0ajy60wlgRJhBXSGhpqb2CNnZhHBkZORcqBEMDFBX2BsYGGBVjAv39vZaQ41gYIC6Ygs2hbiwr6/vdqA+DqgR4CiW19bWxqoYF87Ly4uFaocAZWXlydgU4sJ2dna3ga4QgGqHAC0trY/YFOPCKSkpDVCtCAA01QaIsaYJHFgCqpVagIEBACGlF2c3r4ViAAAAAElFTkSuQmCC) no-repeat 8px 6px;
-}
 
 .phpdebugbar-indicator {
   position: relative;

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -484,19 +484,25 @@ if (typeof(PhpDebugBar) == 'undefined') {
             };
 
             // close button
-            this.$closebtn = $('<a />').addClass(csscls('close-btn')).appendTo(this.$headerRight);
+            this.$closebtn = $('<a />').addClass(csscls('close-btn'))
+                .append($('<span />').addClass(csscls('fa fa-times')))
+                .appendTo(this.$headerRight);
             this.$closebtn.click(function() {
                 self.close();
             });
 
             // minimize button
-            this.$minimizebtn = $('<a />').addClass(csscls('minimize-btn') ).appendTo(this.$headerRight);
+            this.$minimizebtn = $('<a />').addClass(csscls('minimize-btn'))
+                .append($('<span />').addClass(csscls('fa fa-chevron-down')))
+                .appendTo(this.$headerRight);
             this.$minimizebtn.click(function() {
                 self.minimize();
             });
 
             // maximize button
-            this.$maximizebtn = $('<a />').addClass(csscls('maximize-btn') ).appendTo(this.$headerRight);
+            this.$maximizebtn = $('<a />').addClass(csscls('maximize-btn') )
+                .append($('<span />').addClass(csscls('fa fa-chevron-up')))
+                .appendTo(this.$headerRight);
             this.$maximizebtn.click(function() {
                 self.restore();
             });
@@ -508,7 +514,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             });
 
             // open button
-            this.$openbtn = $('<a />').addClass(csscls('open-btn')).appendTo(this.$headerRight).hide();
+            this.$openbtn = $('<a />').addClass(csscls('open-btn'))
+                .append($('<span />').addClass(csscls('fa fa-folder-open')))
+                .appendTo(this.$headerRight).hide();
             this.$openbtn.click(function() {
                 self.openHandler.show(function(id, dataset) {
                     self.addDataSet(dataset, id, "(opened)");


### PR DESCRIPTION
When calling TraceablePDO::query() without PDO::ERRMODE_EXCEPTION I can’t call TraceablePDO::errorInfo() because it has been reset by the internal call to PDO::getAttribute(PDO::ATTR_ERRMODE).

This PR moves the calling of PDO::getAttribute(PDO::ATTR_ERRMODE) to above the actual query so that the error information from the actual query stays on the PDO object.