### PR TITLE
[WIP] Add resettable interface for Collectors

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -15,7 +15,7 @@ use Exception;
 /**
  * Collects info about exceptions
  */
-class ExceptionsCollector extends DataCollector implements Renderable
+class ExceptionsCollector extends DataCollector implements Renderable, Resettable
 {
     protected $exceptions = array();
     protected $chainExceptions = false;
@@ -51,6 +51,11 @@ class ExceptionsCollector extends DataCollector implements Renderable
     public function getExceptions()
     {
         return $this->exceptions;
+    }
+
+    public function reset()
+    {
+        $this->exceptions = array();
     }
 
     public function collect()

--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -16,7 +16,7 @@ use DebugBar\DataFormatter\DataFormatterInterface;
 /**
  * Provides a way to log messages
  */
-class MessagesCollector extends AbstractLogger implements DataCollectorInterface, MessagesAggregateInterface, Renderable, ResetCollectorInterface
+class MessagesCollector extends AbstractLogger implements DataCollectorInterface, MessagesAggregateInterface, Renderable, Resettable
 {
     protected $name;
 

--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -16,7 +16,7 @@ use DebugBar\DataFormatter\DataFormatterInterface;
 /**
  * Provides a way to log messages
  */
-class MessagesCollector extends AbstractLogger implements DataCollectorInterface, MessagesAggregateInterface, Renderable
+class MessagesCollector extends AbstractLogger implements DataCollectorInterface, MessagesAggregateInterface, Renderable, ResetCollectorInterface
 {
     protected $name;
 
@@ -51,6 +51,21 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
             $this->dataFormater = DataCollector::getDefaultDataFormatter();
         }
         return $this->dataFormater;
+    }
+
+    /**
+     * Reset the collector to its initial state.
+     *
+     * @return void
+     */
+    function reset()
+    {
+        $this->messages = array();
+        foreach ($this->aggregates as $collector) {
+            if ($collector instanceof ResetCollectorInterface){
+                $collector->reset();
+            }
+        }
     }
 
     /**

--- a/src/DebugBar/DataCollector/ResetCollectorInterface.php
+++ b/src/DebugBar/DataCollector/ResetCollectorInterface.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of the DebugBar package.
+ *
+ * (c) 2013 Maxime Bouroumeau-Fuseau
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DebugBar\DataCollector;
+
+/**
+ * DataReset Interface
+ */
+interface ResetCollectorInterface
+{
+    /**
+     * Reset the collector to its initial state.
+     *
+     * @return void
+     */
+    function reset();
+}

--- a/src/DebugBar/DataCollector/Resettable.php
+++ b/src/DebugBar/DataCollector/Resettable.php
@@ -11,9 +11,9 @@
 namespace DebugBar\DataCollector;
 
 /**
- * DataReset Interface
+ * Resettable Interface
  */
-interface ResetCollectorInterface
+interface Resettable
 {
     /**
      * Reset the collector to its initial state.

--- a/src/DebugBar/DataCollector/TimeDataCollector.php
+++ b/src/DebugBar/DataCollector/TimeDataCollector.php
@@ -16,7 +16,7 @@ use DebugBar\DebugBarException;
  * Collects info about the request duration as well as providing
  * a way to log duration of any operations
  */
-class TimeDataCollector extends DataCollector implements Renderable, ResetCollectorInterface
+class TimeDataCollector extends DataCollector implements Renderable, Resettable
 {
     /**
      * @var float

--- a/src/DebugBar/DataCollector/TimeDataCollector.php
+++ b/src/DebugBar/DataCollector/TimeDataCollector.php
@@ -16,7 +16,7 @@ use DebugBar\DebugBarException;
  * Collects info about the request duration as well as providing
  * a way to log duration of any operations
  */
-class TimeDataCollector extends DataCollector implements Renderable
+class TimeDataCollector extends DataCollector implements Renderable, ResetCollectorInterface
 {
     /**
      * @var float
@@ -43,14 +43,20 @@ class TimeDataCollector extends DataCollector implements Renderable
      */
     public function __construct($requestStartTime = null)
     {
-        if ($requestStartTime === null) {
-            if (isset($_SERVER['REQUEST_TIME_FLOAT'])) {
-                $requestStartTime = $_SERVER['REQUEST_TIME_FLOAT'];
-            } else {
-                $requestStartTime = microtime(true);
-            }
-        }
         $this->requestStartTime = $requestStartTime;
+        if ($this->requestStartTime === null) {
+            $this->getRequestStartTime();
+        }
+    }
+
+    /**
+     * Reset thet start/end time and measures
+     */
+    public function reset()
+    {
+        $this->requestStartTime = null;
+        $this->requestEndTime = null;
+        $this->startedMeasures = array();
     }
 
     /**
@@ -118,7 +124,7 @@ class TimeDataCollector extends DataCollector implements Renderable
         $this->measures[] = array(
             'label' => $label,
             'start' => $start,
-            'relative_start' => $start - $this->requestStartTime,
+            'relative_start' => $start - $this->getRequestStartTime(),
             'end' => $end,
             'relative_end' => $end - $this->requestEndTime,
             'duration' => $end - $start,
@@ -161,6 +167,14 @@ class TimeDataCollector extends DataCollector implements Renderable
      */
     public function getRequestStartTime()
     {
+        if ($this->requestStartTime === null) {
+            if (isset($_SERVER['REQUEST_TIME_FLOAT'])) {
+                $this->requestStartTime = $_SERVER['REQUEST_TIME_FLOAT'];
+            } else {
+                $this->requestStartTime = microtime(true);
+            }
+        }
+
         return $this->requestStartTime;
     }
 
@@ -182,9 +196,9 @@ class TimeDataCollector extends DataCollector implements Renderable
     public function getRequestDuration()
     {
         if ($this->requestEndTime !== null) {
-            return $this->requestEndTime - $this->requestStartTime;
+            return $this->requestEndTime - $this->getRequestStartTime();
         }
-        return microtime(true) - $this->requestStartTime;
+        return microtime(true) - $this->getRequestStartTime();
     }
 
     public function collect()
@@ -195,7 +209,7 @@ class TimeDataCollector extends DataCollector implements Renderable
         }
 
         return array(
-            'start' => $this->requestStartTime,
+            'start' => $this->getRequestStartTime(),
             'end' => $this->requestEndTime,
             'duration' => $this->getRequestDuration(),
             'duration_str' => $this->getDataFormatter()->formatDuration($this->getRequestDuration()),

--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -11,6 +11,7 @@
 namespace DebugBar;
 
 use ArrayAccess;
+use DebugBar\DataCollector\Resettable;
 use DebugBar\DataCollector\DataCollectorInterface;
 use DebugBar\Storage\StorageInterface;
 
@@ -227,6 +228,23 @@ class DebugBar implements ArrayAccess
         }
 
         return $this->data;
+    }
+    
+    /**
+     * Reset the collectors and the DebugBar to the initial state.
+     *
+     * @return string
+     */
+    public function reset()
+    {
+        foreach ($this->collectors as $collector) {
+            if ($collector instanceof Resettable){
+                $collector->reset();
+            }
+        }
+
+        $this->requestId = null;
+        $this->data = null;
     }
 
     /**


### PR DESCRIPTION
This is aimed specifically for https://github.com/php-pm/php-pm but could be used for other concurrent request frameworks (which I don't know of).

Adds a `reset()` method to the collectors to reset the state. Eg. clear the messages, reset starting time etc.
Not all collectors have been done yet, not all need it.

This can be used like `$debugbar->reset()` to reset all collectors, the collected data and regenerate an request id.
For Laravel this can be called in the middleware, after handling the request. For PHP-PM, this avoids duplicate entries etc.