### PR TITLE
Go with the most semantically correct option

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -10,7 +10,6 @@
 
 namespace DebugBar\DataCollector;
 
-use Error;
 use Exception;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 
@@ -31,7 +30,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     {
         $this->exceptions[] = $e;
         if ($this->chainExceptions && $previous = $e->getPrevious()) {
-            if ($previous instanceof Error) {
+            if (!$previous instanceof Exception) {
                 $previous = new FatalThrowableError($previous);
             }
             $this->addException($previous);


### PR DESCRIPTION
We only want exceptions, so if it's not an exception, convert it to one. We shouldn't rely on the fact that it would be an Error otherwise.