### PR TITLE
Add Throwables, deprecate exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "require": {
         "php": ">=5.3.0",
         "psr/log": "^1.0",
-        "symfony/var-dumper": "^2.6|^3.0",
-        "symfony/debug": "^2.6|^3.0"
+        "symfony/var-dumper": "^2.6|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0"

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -25,15 +25,23 @@ class ExceptionsCollector extends DataCollector implements Renderable
      * Adds an exception to be profiled in the debug bar
      *
      * @param Exception $e
+     * @deprecated in favor on addThrowable
      */
-    public function addException(Exception $e)
+    public function addException($e)
+    {
+        $this->addThrowable($e);
+    }
+
+    /**
+     * Adds a Throwable to be profiled in the debug bar
+     *
+     * @param \Throwable|\Exception $e
+     */
+    public function addThrowable($e)
     {
         $this->exceptions[] = $e;
         if ($this->chainExceptions && $previous = $e->getPrevious()) {
-            if (!$previous instanceof Exception) {
-                $previous = new FatalThrowableError($previous);
-            }
-            $this->addException($previous);
+            $this->addThrowable($previous);
         }
     }
 
@@ -50,7 +58,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Returns the list of exceptions being profiled
      *
-     * @return array[Exception]
+     * @return array[\Throwable|\Exception]
      */
     public function getExceptions()
     {
@@ -61,7 +69,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     {
         return array(
             'count' => count($this->exceptions),
-            'exceptions' => array_map(array($this, 'formatExceptionData'), $this->exceptions)
+            'exceptions' => array_map(array($this, 'formatThrowableData'), $this->exceptions)
         );
     }
 
@@ -70,8 +78,20 @@ class ExceptionsCollector extends DataCollector implements Renderable
      *
      * @param Exception $e
      * @return array
+     * @deprecated in favor on formatThrowableData
      */
     public function formatExceptionData(Exception $e)
+    {
+        return $this->formatThrowableData($e);
+    }
+
+    /**
+     * Returns exception data as an array
+     *
+     * @param Exception $e
+     * @return array
+     */
+    public function formatThrowableData($e)
     {
         $filePath = $e->getFile();
         if ($filePath && file_exists($filePath)) {

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -86,9 +86,9 @@ class ExceptionsCollector extends DataCollector implements Renderable
     }
 
     /**
-     * Returns exception data as an array
+     * Returns Throwable data as an array
      *
-     * @param Exception $e
+     * @param \Throwable $e
      * @return array
      */
     public function formatThrowableData($e)

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -58,7 +58,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Returns the list of exceptions being profiled
      *
-     * @return array[\Throwable|\Exception]
+     * @return array[\Throwable]
      */
     public function getExceptions()
     {

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -27,7 +27,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
      * @param Exception $e
      * @deprecated in favor on addThrowable
      */
-    public function addException($e)
+    public function addException(Exception $e)
     {
         $this->addThrowable($e);
     }
@@ -35,7 +35,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Adds a Throwable to be profiled in the debug bar
      *
-     * @param \Throwable|\Exception $e
+     * @param \Throwable $e
      */
     public function addThrowable($e)
     {


### PR DESCRIPTION
Instead of transforming them to Exceptions, we could still just parse them.
We need to deprecate the public methods, because of the typhints, so implementations can use the new methods instead.
cc @jamiehd @GrahamCampbell 