### PR TITLE
Aggregate Timeline Measures

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -368,10 +368,29 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
         render: function() {
             this.bindAttr('data', function(data) {
+
+                // ported from php DataFormatter
+                var formatDuration = function(seconds) {
+                    if (seconds < 0.001)
+                        return (seconds * 1000000).toFixed() + 'μs';
+                    else if (seconds < 1)
+                        return (seconds * 1000).toFixed(2) + 'ms';
+                    return (seconds).toFixed(2) +  's';
+                };
+
                 this.$el.empty();
                 if (data.measures) {
+                    var aggregate = {};
+
                     for (var i = 0; i < data.measures.length; i++) {
                         var measure = data.measures[i];
+
+                        if(!aggregate[measure.label])
+                            aggregate[measure.label] = { count: 0, duration: 0 };
+
+                        aggregate[measure.label]['count'] += 1;
+                        aggregate[measure.label]['duration'] += measure.duration;
+
                         var m = $('<div />').addClass(csscls('measure')),
                             li = $('<li />'),
                             left = (measure.relative_start * 100 / data.duration).toFixed(2),
@@ -408,6 +427,30 @@ if (typeof(PhpDebugBar) == 'undefined') {
                             });
                         }
                     }
+
+                    // convert to array and sort by duration
+                    aggregate = $.map(aggregate, function(data, label) {
+                       return {
+                           label: label,
+                           data: data
+                       }
+                    }).sort(function(a, b) {
+                        return b.data.duration - a.data.duration
+                    });
+
+                    // build table and add
+                    var aggregateTable = $('<table style="display: table; border: 0; width: 99%"></table>').addClass(csscls('params'));
+                    $.each(aggregate, function(i, aggregate) {
+                        width = Math.min((aggregate.data.duration * 100 / data.duration).toFixed(2), 100);
+
+                        aggregateTable.append('<tr><td class="' + csscls('name') + '">' + aggregate.data.count + ' x ' + aggregate.label + ' (' + width + '%)</td><td class="' + csscls('value') + '">' +
+                            '<div class="' + csscls('measure') +'">' +
+                                '<span class="' + csscls('value') + '" style="width:' + width + '%"></span>' +
+                                '<span class="' + csscls('label') + '">' + formatDuration(aggregate.data.duration) + '</span>' +
+                            '</div></td></tr>');
+                    });
+
+                    this.$el.append('<li/>').find('li:last').append(aggregateTable);
                 }
             });
         }


### PR DESCRIPTION
This aggregates all time measures with the same label and displays the count and total duration in a table on the Timeline tab. 

![image](https://cloud.githubusercontent.com/assets/19486346/16872474/4a0c899c-4a8d-11e6-8211-90686a1b4483.png)

I am not sure this will be useful for others but it has helped me a lot to debug performance issues when there are many small steps involved and it is not clear which of the small steps are adding up most. 
Without this code would have to be rearranged to fit into a single measurement.
