### PR TITLE
forces direction of text to be ltr

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -19,6 +19,7 @@ div.phpdebugbar {
   text-align: left;
   line-height: 1;
   letter-spacing: normal;
+  direction: ltr;
 }
 
 div.phpdebugbar a,


### PR DESCRIPTION
Fix for issue https://github.com/maximebf/php-debugbar/issues/266

Instead of inheriting text direction, this will force it to be left to right.