### PR TITLE
Added array reverse to find results

### DIFF
--- a/src/DebugBar/Storage/MemcachedStorage.php
+++ b/src/DebugBar/Storage/MemcachedStorage.php
@@ -68,6 +68,7 @@ class MemcachedStorage implements StorageInterface
                 }
             }
         }
+        $results = array_reverse($results);
         return array_slice($results, $offset, $max);
     }
 


### PR DESCRIPTION
The OpenHandler modal returns results in oldest first order by default, changed storage find method so newest entries are at the top.
