### PR TITLE
Check for unsafe header

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1019,6 +1019,10 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @return {Bool}
          */
         handle: function(xhr) {
+             // Check if the debugbar header is available
+            if (xhr.getAllResponseHeaders().indexOf(this.headerName) === -1){
+                return true;
+            }
             if (!this.loadFromId(xhr)) {
                 return this.loadFromData(xhr);
             }


### PR DESCRIPTION
Some headers are unsafe to read (in Chrome), checking all returned headers will prevent these errors. See https://github.com/barryvdh/laravel-debugbar/issues/384