### PR TITLE
Fix front-end crash when there are no twig templates

### DIFF
--- a/src/DebugBar/Bridge/Twig/TwigCollector.php
+++ b/src/DebugBar/Bridge/Twig/TwigCollector.php
@@ -68,7 +68,7 @@ class TwigCollector extends DataCollector implements Renderable, AssetProvider
                 'icon' => 'leaf',
                 'widget' => 'PhpDebugBar.Widgets.TemplatesWidget',
                 'map' => 'twig',
-                'default' => '[]'
+                'default' => json_encode(array('templates' => array())),
             ),
             'twig:badge' => array(
                 'map' => 'twig.nb_templates',


### PR DESCRIPTION
If there aren’t any templates, the twig widget crashes the client.  Fix
the bug by safely checking for null and assuming 0 if so.