### PR TITLE
TimeDataCollector sorts measurements by start time

### DIFF
--- a/src/DebugBar/DataCollector/TimeDataCollector.php
+++ b/src/DebugBar/DataCollector/TimeDataCollector.php
@@ -198,6 +198,13 @@ class TimeDataCollector extends DataCollector implements Renderable
             $this->stopMeasure($name);
         }
 
+        usort($this->measures, function($a, $b) {
+            if ($a['start'] == $b['start']) {
+                return 0;
+            }
+            return $a['start'] < $b['start'] ? -1 : 1;
+        });
+
         return array(
             'start' => $this->requestStartTime,
             'end' => $this->requestEndTime,


### PR DESCRIPTION
Sometimes, users of this collector may not add measurements in order of
the start time.  For example, various existing measurement systems may
feed existing measurements into this class via the addMeasure function.

Sort the measurements by start time during collection.  This yields a
nice, chronological view of the measurements, similar to Chrome
DevTools.