### PR TITLE
Use system fonts

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -11,7 +11,7 @@ div.phpdebugbar {
   left: 0;
   width: 100%;
   border-top: 0;
-  font-family: arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif;
   background: #fff;
   z-index: 10000;
   font-size: 14px;
@@ -66,7 +66,7 @@ div.phpdebugbar table {
 
 div.phpdebugbar code, div.phpdebugbar pre {
   background: none;
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   font-size: 1em;
   border: 0;
   padding: 0;

--- a/src/DebugBar/Resources/openhandler.css
+++ b/src/DebugBar/Resources/openhandler.css
@@ -22,7 +22,7 @@ div.phpdebugbar-openhandler {
     border: 2px solid #888;
     overflow: auto;
     z-index: 20001;
-    font-family: arial;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 14px;
     padding-bottom: 10px;
 }

--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -2,7 +2,7 @@ ul.phpdebugbar-widgets-list {
   margin: 0;
   padding: 0;
   list-style: none;
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 }
   ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item {
     padding: 3px 6px;
@@ -114,7 +114,7 @@ dl.phpdebugbar-widgets-kvlist {
 /* -------------------------------------- */
 
 dl.phpdebugbar-widgets-varlist {
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 }
 
 /* -------------------------------------- */
@@ -137,7 +137,7 @@ ul.phpdebugbar-widgets-timeline {
     ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-collector {
       position: absolute;
       font-size: 12px;
-      font-family: monospace;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
       color: #555;
       top: 4px;
       left: 5px;
@@ -151,7 +151,7 @@ ul.phpdebugbar-widgets-timeline {
       right: 5px;
     }
     ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-value {
-      display: block; 
+      display: block;
       position: absolute;
       height: 10px;
       background: #3db9ec;
@@ -164,7 +164,7 @@ ul.phpdebugbar-widgets-timeline {
       width: 70%;
       margin: 10px;
       border: 1px solid #ddd;
-      font-family: monospace;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
       border-collapse: collapse;
     }
       ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params td {
@@ -205,5 +205,5 @@ div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item {
     margin: 10px;
     padding: 5px;
     border: 1px solid #ddd;
-    font-family: monospace;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   }

--- a/src/DebugBar/Resources/widgets/mails/widget.css
+++ b/src/DebugBar/Resources/widgets/mails/widget.css
@@ -8,5 +8,5 @@ div.phpdebugbar-widgets-mails li.phpdebugbar-widgets-list-item pre.phpdebugbar-w
   margin: 10px;
   padding: 5px;
   border: 1px solid #ddd;
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 }

--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.css
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.css
@@ -1,5 +1,5 @@
 div.phpdebugbar-widgets-sqlqueries .phpdebugbar-widgets-status {
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   padding: 6px 6px;
   border-bottom: 1px solid #ddd;
   font-weight: bold;
@@ -56,7 +56,7 @@ div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params {
   width: 70%;
   margin: 10px;
   border: 1px solid #ddd;
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   border-collapse: collapse;
 }
   div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params td {

--- a/src/DebugBar/Resources/widgets/templates/widget.css
+++ b/src/DebugBar/Resources/widgets/templates/widget.css
@@ -1,6 +1,6 @@
 
 div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status {
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   padding: 6px 6px;
   border-bottom: 1px solid #ddd;
   font-weight: bold;
@@ -47,7 +47,7 @@ div.phpdebugbar-widgets-templates table.phpdebugbar-widgets-params {
   width: 70%;
   margin: 10px;
   border: 1px solid #ddd;
-  font-family: monospace;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   border-collapse: collapse;
 }
 div.phpdebugbar-widgets-templates table.phpdebugbar-widgets-params td {


### PR DESCRIPTION
Use system fonts to match current OS UI chrome for `sans-serif` and
`monospace` fonts, giving a more consistent look with the OS and other
developer tools in the browser.

As as side note, this technique is also used by GitHub.
Also, font-awesome icons on the same line with monospace text are now correctly aligned.

Read more: https://css-tricks.com/snippets/css/system-font-stack/

Here is a screenshot on macOS Sierra:

![laravel-debugbar-queries](https://cloud.githubusercontent.com/assets/667144/23094369/3fce97f8-f600-11e6-8648-ca5ec50a3944.png)
