### PR TITLE
Add real usage option to memory collection

### DIFF
--- a/src/DebugBar/DataCollector/MemoryCollector.php
+++ b/src/DebugBar/DataCollector/MemoryCollector.php
@@ -15,7 +15,31 @@ namespace DebugBar\DataCollector;
  */
 class MemoryCollector extends DataCollector implements Renderable
 {
+    protected $realUsage = false;
+
     protected $peakUsage = 0;
+
+    /**
+     * Returns whether total allocated memory page size is used instead of actual used memory size
+     * by the application.  See $real_usage parameter on memory_get_peak_usage for details.
+     *
+     * @return bool
+     */
+    public function getRealUsage()
+    {
+        return $this->realUsage;
+    }
+
+    /**
+     * Sets whether total allocated memory page size is used instead of actual used memory size
+     * by the application.  See $real_usage parameter on memory_get_peak_usage for details.
+     *
+     * @param bool $realUsage
+     */
+    public function setRealUsage($realUsage)
+    {
+        $this->realUsage = $realUsage;
+    }
 
     /**
      * Returns the peak memory usage
@@ -32,7 +56,7 @@ class MemoryCollector extends DataCollector implements Renderable
      */
     public function updatePeakUsage()
     {
-        $this->peakUsage = memory_get_peak_usage(true);
+        $this->peakUsage = memory_get_peak_usage($this->realUsage);
     }
 
     /**

--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -46,7 +46,7 @@ class TracedStatement
     public function start($startTime = null, $startMemory = null)
     {
         $this->startTime = $startTime ?: microtime(true);
-        $this->startMemory = $startMemory ?: memory_get_usage(true);
+        $this->startMemory = $startMemory ?: memory_get_usage(false);
     }
 
     /**
@@ -59,7 +59,7 @@ class TracedStatement
     {
         $this->endTime = $endTime ?: microtime(true);
         $this->duration = $this->endTime - $this->startTime;
-        $this->endMemory = $endMemory ?: memory_get_usage(true);
+        $this->endMemory = $endMemory ?: memory_get_usage(false);
         $this->memoryDelta = $this->endMemory - $this->startMemory;
         $this->exception = $exception;
         $this->rowCount = $rowCount;


### PR DESCRIPTION
The memory_get_usage and memory_get_peak_usage functions have a
$real_usage parameter.  Update the MemoryCollector and PDOCollector
collectors to allow the user to choose which type of memory usage to
gather.

To recap, when $real_usage is set (and previously this was the
hard-coded default), PHP returns the amount of memory allocated from the
operating system by the PHP memory manager.  This is typically done in
large chunks of memory and is not very granular.

When $real_usage is cleared, PHP returns the amount of memory the user’s
application has actually allocated from the PHP memory manager.

Clearing $real_usage has useful application especially for the
PDOCollector.  As an example, a query that returns only a few rows will
often say that zero bytes were used when $real_usage is set.  That’s
because PHP was able to satisfy the memory requests from memory it had
already allocated from the operating system.  To contrast, the same
query will show an expected few kilobytes of memory usage when
$real_usage is set to false.