### PR TITLE
Support debug bar collection from command-line

### DIFF
--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -204,14 +204,27 @@ class DebugBar implements ArrayAccess
      */
     public function collect()
     {
-        $this->data = array(
-            '__meta' => array(
-                'id' => $this->getCurrentRequestId(),
-                'datetime' => date('Y-m-d H:i:s'),
-                'utime' => microtime(true),
+        if (php_sapi_name() === 'cli') {
+            $request_variables = array(
+                'method' => 'CLI',
+                'uri' => isset($_SERVER['SCRIPT_FILENAME']) ? realpath($_SERVER['SCRIPT_FILENAME']) : null,
+                'ip' => gethostbyname(gethostname())
+            );
+        } else {
+            $request_variables = array(
                 'method' => isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : null,
                 'uri' => isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null,
                 'ip' => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : null
+            );
+        }
+        $this->data = array(
+            '__meta' => array_merge(
+                array(
+                    'id' => $this->getCurrentRequestId(),
+                    'datetime' => date('Y-m-d H:i:s'),
+                    'utime' => microtime(true)
+                ),
+                $request_variables
             )
         );
 

--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -205,10 +205,16 @@ class DebugBar implements ArrayAccess
     public function collect()
     {
         if (php_sapi_name() === 'cli') {
+            $ip = gethostname();
+            if ($ip) {
+                $ip = gethostbyname($ip);
+            } else {
+                $ip = '127.0.0.1';
+            }
             $request_variables = array(
                 'method' => 'CLI',
                 'uri' => isset($_SERVER['SCRIPT_FILENAME']) ? realpath($_SERVER['SCRIPT_FILENAME']) : null,
-                'ip' => gethostbyname(gethostname())
+                'ip' => $ip
             );
         } else {
             $request_variables = array(


### PR DESCRIPTION
It can be useful to use the PHP Debug Bar from the command line if a
storage layer is configured.  In that scenario, a user would run a PHP
CLI application, then open a web page with the debug bar front-end and
use the open handler to locate the command-line invocation.

However, a problem is that the collect() function assumes that standard
HTTP variables are available - this assumption does not apply when
running from the CLI.  Write a special branch of code for the CLI server
API so that reasonable metadata can be collected for the CLI case.

Without this patch, null method, URI, and IP are logged and it actually
becomes impossible to open the CLI invocation in the open handler - let
alone tell them apart.