### PR TITLE
Fix twig template instance check

### DIFF
--- a/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
+++ b/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
@@ -16,7 +16,7 @@ use Twig_TemplateInterface;
 /**
  * Wraps a Twig_Template to add profiling features
  */
-class TraceableTwigTemplate implements Twig_TemplateInterface
+class TraceableTwigTemplate extends Twig_Template implements Twig_TemplateInterface
 {
     protected $template;
 
@@ -33,6 +33,11 @@ class TraceableTwigTemplate implements Twig_TemplateInterface
     public function __call($name, $arguments)
     {
         return call_user_func_array(array($this->template, $name), $arguments);
+    }
+
+    public function doDisplay(array $context, array $blocks = array())
+    {
+        return $this->template->doDisplay($context, $blocks);
     }
 
     public function getTemplateName()


### PR DESCRIPTION
Fix for  #330

Twig was unable to check for template being instance of self because Traceable twig template was not extending it.
Please note that since version 2 of twig, Twig_Template does not implement Twig_TemplateInterface  and Twig_TemplateInterface will be removed in version 3.x and thus phpdebugbar should do so. 