### PR TITLE
Fix line breaking for tab badges

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -170,6 +170,9 @@ a.phpdebugbar-tab.phpdebugbar-active {
     display: none;
     vertical-align: middle;
   }
+  a.phpdebugbar-tab span.phpdebugbar-badge.phpdebugbar-visible {
+    display: inline;
+  }
   a.phpdebugbar-tab span.phpdebugbar-badge.phpdebugbar-important {
     background: #ed6868;
     color: white;

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -272,9 +272,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.bindAttr('badge', function(value) {
                 if (value !== null) {
                     this.$badge.text(value);
-                    this.$badge.show();
+                    this.$badge.addClass(csscls('visible'));
                 } else {
-                    this.$badge.hide();
+                    this.$badge.removeClass(csscls('visible'));
                 }
             });
 


### PR DESCRIPTION
Small fix for badges in tabs.
The problem appears when body element has `display: flex` style so jQuery's `.show()` function add `display="block"` instead of `display="inline"` to badges `span` element.

<img width="793" alt="2017-06-04 18 03 27" src="https://cloud.githubusercontent.com/assets/3776001/26762764/4bb42fee-4950-11e7-89aa-c0ff291ab541.png">
