### PR TITLE
Set code/pre color to black

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -68,6 +68,7 @@ div.phpdebugbar code, div.phpdebugbar pre {
   background: none;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   font-size: 1em;
+  color: #000;
   border: 0;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
Some existing user-provided stylesheets on the page might have a
different default color for code and pre elements; set it to black:
similar to what is already being done with the root div.phpdebugbar
style.