### PR TITLE
RequestIdGeneratorInterface now requires a unique ID on each call

### DIFF
--- a/src/DebugBar/RequestIdGenerator.php
+++ b/src/DebugBar/RequestIdGenerator.php
@@ -11,15 +11,33 @@
 namespace DebugBar;
 
 /**
- * Request id generator based on the $_SERVER array
+ * Basic request ID generator
  */
 class RequestIdGenerator implements RequestIdGeneratorInterface
 {
+    protected $index = 0;
+
     /**
      * @return string
      */
     public function generate()
     {
-        return md5(serialize($_SERVER) . microtime());
+        if (function_exists('random_bytes')) {
+            // PHP 7 only
+            return 'X' . bin2hex(random_bytes(16));
+        } else if (function_exists('openssl_random_pseudo_bytes')) {
+            // PHP >= 5.3.0, but OpenSSL may not always be available
+            return 'X' . bin2hex(openssl_random_pseudo_bytes(16));
+        } else {
+            // Fall back to a rudimentary ID generator:
+            //  * $_SERVER array will make the ID unique to this request.
+            //  * spl_object_hash($this) will make the ID unique to this object instance.
+            //    (note that object hashes can be reused, but the other data here should prevent issues here).
+            //  * uniqid('', true) will use the current microtime(), plus additional random data.
+            //  * $this->index guarantees the uniqueness of IDs from the current object.
+            $this->index++;
+            $entropy = serialize($_SERVER) . uniqid('', true) . spl_object_hash($this) . $this->index;
+            return 'X' . md5($entropy);
+        }
     }
 }

--- a/src/DebugBar/RequestIdGeneratorInterface.php
+++ b/src/DebugBar/RequestIdGeneratorInterface.php
@@ -13,7 +13,11 @@ namespace DebugBar;
 interface RequestIdGeneratorInterface
 {
     /**
-     * Generates a unique id for the current request
+     * Generates a unique id for the current request.  If called repeatedly, a new unique id must
+     * always be returned on each call to generate() - even across different object instances.
+     *
+     * To avoid any potential confusion in ID --> value maps, the returned value must be
+     * guaranteed to not be all-numeric.
      *
      * @return string
      */


### PR DESCRIPTION
Implementers of `RequestIdGeneratorInterface::generate()` need to be sure that each call to `generate()` will return a unique ID.

This could fail to happen in the existing implementation if `microtime()` returns the same value on two successive `generate()` calls that come within the same microsecond.  For example, in a tight ID-generating loop.  It was unlikely, but now it is practically impossible.

Additionally, implementers should make sure that the return value is not all-numeric to avoid any mixed data types when IDs are used as keys in PHP arrays.  (For example, numeric IDs could result in bugs when `array_merge` is used.)