### PR TITLE
Add line number and line highlighting support to createCodeBlock

### DIFF
--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -1,3 +1,36 @@
+pre.phpdebugbar-widgets-code-block {
+    white-space: pre;
+    word-wrap: normal;
+    overflow: hidden;
+}
+  pre.phpdebugbar-widgets-code-block code {
+    display: block;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+  pre.phpdebugbar-widgets-code-block code.phpdebugbar-widgets-numbered-code {
+    padding: 5px;
+  }
+    pre.phpdebugbar-widgets-code-block code span.phpdebugbar-widgets-highlighted-line {
+      background: #800000;
+      color: #fff;
+      display: inline-block;
+      min-width: 100%;
+    }
+      pre.phpdebugbar-widgets-code-block code span.phpdebugbar-widgets-highlighted-line span {
+        background: none !important;
+        color: inherit !important;
+      }
+  pre.phpdebugbar-widgets-code-block ul {
+    float: left;
+    padding: 5px;
+    background: #cacaca;
+    border-right: 1px solid #aaa;
+    text-align: right;
+  }
+
+/* -------------------------------------- */
+
 ul.phpdebugbar-widgets-list {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
When showing backtraces, it’s useful to:

1. Show line numbers for each line of contextual code.
1. Highlight the line from the backtrace.

This commit adds the functionality to `widgets.js`/`css` for doing this.

Screenshot of functionality with highlight.js:
![screen shot 2017-07-14 at 4 21 42 pm](https://user-images.githubusercontent.com/22308682/28234271-a842e1ca-68b2-11e7-9a62-d85628b7d1fa.png)

Screenshot of functionality without highlight.js:
![screen shot 2017-07-14 at 4 24 48 pm](https://user-images.githubusercontent.com/22308682/28234273-b0a84d6e-68b2-11e7-9bce-180edffcf509.png)
