### PR TITLE
Fix misc. style sheet problems with MessagesWidget

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -64,6 +64,16 @@ div.phpdebugbar table {
   border-spacing: 0;
 }
 
+div.phpdebugbar input[type='text'], div.phpdebugbar input[type='password'] {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background: #fff;
+  font-size: 14px;
+  color: #000;
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
 div.phpdebugbar code, div.phpdebugbar pre {
   background: none;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;

--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -20,7 +20,7 @@ div.phpdebugbar-widgets-messages {
   position: relative;
   height: 100%;
 }
-  div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-list {
+  div.phpdebugbar-widgets-messages ul.phpdebugbar-widgets-list {
     padding-bottom: 20px;
   }
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-warning:before {


### PR DESCRIPTION
1. The list of messages was missing `padding-bottom`, causing the search box to obscure the bottom message.
1. Explicitly declare styles for text input elements to avoid interference from the containing page’s stylesheet.  (On our site, text input elements had 10px padding, causing the search box to be much larger than the `padding-bottom` margin allowed for.)