### PR TITLE
Improve efficiency of memcached find

### DIFF
--- a/src/DebugBar/Storage/MemcachedStorage.php
+++ b/src/DebugBar/Storage/MemcachedStorage.php
@@ -11,6 +11,7 @@
 namespace DebugBar\Storage;
 
 use Memcached;
+use ReflectionMethod;
 
 /**
  * Stores collected data into Memcache using the Memcached extension
@@ -22,6 +23,8 @@ class MemcachedStorage implements StorageInterface
     protected $keyNamespace;
 
     protected $expiration;
+
+    protected $newGetMultiSignature;
 
     /**
      * @param Memcached $memcached
@@ -68,16 +71,32 @@ class MemcachedStorage implements StorageInterface
         }
 
         $results = array();
-        foreach (explode('|', $keys) as $key) {
-            if ($data = $this->memcached->get($key)) {
-                $meta = $data['__meta'];
-                if ($this->filter($meta, $filters)) {
-                    $results[] = $meta;
+        $keys = array_reverse(explode('|', $keys)); // Reverse so newest comes first
+        $keyPosition = 0; // Index in $keys to try to get next items from
+        $remainingItems = $max + $offset; // Try to obtain this many remaining items
+        // Loop until we've found $remainingItems matching items or no more items may exist.
+        while ($remainingItems > 0 && $keyPosition < count($keys)) {
+            // Consume some keys from $keys:
+            $itemsToGet = array_slice($keys, $keyPosition, $remainingItems);
+            $keyPosition += $remainingItems;
+            // Try to get them, and filter them:
+            $newItems = $this->memcachedGetMulti($itemsToGet, Memcached::GET_PRESERVE_ORDER);
+            if ($newItems) {
+                foreach ($newItems as $data) {
+                    $meta = $data['__meta'];
+                    if ($this->filter($meta, $filters)) {
+                        $remainingItems--;
+                        // Keep the result only if we've discarded $offset items first
+                        if ($offset <= 0) {
+                            $results[] = $meta;
+                        } else {
+                            $offset--;
+                        }
+                    }
                 }
             }
         }
-        $results = array_reverse($results);
-        return array_slice($results, $offset, $max);
+        return $results;
     }
 
     /**
@@ -116,5 +135,24 @@ class MemcachedStorage implements StorageInterface
     protected function createKey($id)
     {
         return md5("{$this->keyNamespace}.$id");
+    }
+
+    /**
+     * The memcached getMulti function changed in version 3.0.0 to only have two parameters.
+     *
+     * @param array $keys
+     * @param int $flags
+     */
+    protected function memcachedGetMulti($keys, $flags)
+    {
+        if ($this->newGetMultiSignature === null) {
+            $this->newGetMultiSignature = (new ReflectionMethod('Memcached', 'getMulti'))->getNumberOfParameters() === 2;
+        }
+        if ($this->newGetMultiSignature) {
+            return $this->memcached->getMulti($keys, $flags);
+        } else {
+            $null = null;
+            return $this->memcached->getMulti($keys, $null, $flags);
+        }
     }
 }


### PR DESCRIPTION
The `find` function for memcached storage is not very efficient when a large number of debug bar frames have been stored over time.  Improve the performance by:

1. Retrieve no more items than absolutely necessary.  (i.e. don’t retrieve every last possible item and then slice the result array.)
1. Use bulk retrieval `getMulti` function with memcached.