### PR TITLE
Introduce DebugBarVarDumper for HTML variable dumping

### DIFF
--- a/docs/data_formatter.md
+++ b/docs/data_formatter.md
@@ -1,9 +1,108 @@
 # Data Formatter
 
+## HTML variable formatting
+
+PHP Debug Bar integrates with Symfony's
+[VarDumper](https://symfony.com/doc/current/components/var_dumper.html) component to provide
+interactive HTML-based variable dumps. This is accomplished via the
+`DebugBar\DataFormatter\DebugBarVarDumper` class, which wraps VarDumper functionality for use by the
+debug bar.
+
+Debug bar users who wish to take advantage of this feature must ensure that they properly render
+[inline assets](rendering.html#assets) when rendering the debug bar. That's because collectors
+using the variable dumper return the static assets of the HTML variable dumper, which includes
+inline assets.
+
+By default, collectors inheriting from `DebugBar\DataCollector\DataCollector` will use the
+`DebugBarVarDumper` instance specified by the static `DataCollector::setDefaultVarDumper` function.
+This can be overridden on a per-collector basis by the non-static `DataCollector::setVarDumper`
+function.
+
+    // Modify default options used globally by all collectors
+    DataCollector::getDefaultVarDumper()->mergeClonerOptions(array(
+        'max_items' => 50,
+    ));
+
+    // Modify options for a specific collector
+    $varDumper = new DebugBarVarDumper();
+    $varDumper->mergeDumperOptions(array(
+        'max_string' => 100,
+    ));
+    $collector->setVarDumper($varDumper);
+
+VarDumper has two key classes that are used by `DebugBarVarDumper`. The options can be set using
+the `mergeClonerOptions`, `resetClonerOptions`, `mergeDumperOptions`, and `resetDumperOptions`
+methods on `DebugBarVarDumper`.
+
+ - `VarCloner`: Cloners copy the contents of a variable into a serializable format. They are
+   intended to run as fast as possible; advanced rendering/formatting is saved for the dumper.
+   Classes known as casters control how particular data types are serialized; if no caster exists,
+   then a generic serialization is done. You can specify custom casters using the
+   `additional_casters` option; the default list of casters can be overridden with the `casters`
+   option. Finally, the number of items and maximum string length to clone can be controlled via the
+   `max_items`, `min_depth`, and `max_string` options; consult the
+   [VarDumper documentation](https://symfony.com/doc/current/components/var_dumper/advanced.html)
+   for more information on these options, which have a considerable performance impact. Note that
+   the `min_depth` option requires VarDumper 3.4 or newer.
+ - `HtmlDumper`: Dumpers format cloned data for a particular destination, such as command-line or
+   HTML. `DebugBarVarDumper` only uses the `HtmlDumper`. Custom styles can be specified via the
+   `styles` option, but this is not generally needed. If using VarDumper 3.2 or newer, you may also
+   specify the `expanded_depth`, `max_string`, and `file_link_format` options. `expanded_depth`
+   controls the tree depth that should be expanded by default upon initial rendering. `max_string`
+   can be used to truncate strings beyond the initial truncation done by the cloner.
+   `file_link_format` is a format string used to generate links to source code files.
+
+A collector wishing to take advantage of this feature must call the `renderVar()` function and
+return the HTML result as part of the request dataset:
+
+    public function collectVariable($v)
+    {
+        // This will clone and then dump the variable in one operation:
+        $this->variableHtml = $this->getVarDumper()->renderVar($v);
+    }
+
+    public function collect()
+    {
+        return array('variableHtml' => $this->variableHtml);
+    }
+
+The collector may then render the raw HTML in a Javascript widget:
+
+    if (value.variableHtml) {
+        var val = $('<span />').html(value.variableHtml).appendTo(otherElement);
+    }
+
+If the collector takes advantage of the variable dumper, as shown above, then it must also
+implement the `AssetProvider` interface and include the assets of the variable dumper. This does
+not take place by default, because not all collectors will use the variable dumper.
+
+    class MyCollector extends DataCollector implements Renderable, AssetProvider
+    {
+        public function getAssets() {
+            return $this->getVarDumper()->getAssets();
+        }
+    }
+
+You might want to clone a variable initially, and only dump it at a later time. This is supported by
+the `captureVar()` and `renderCapturedVar()` functions. It's also possible to render only portions
+of a cloned variable at a time.
+
+    $testData = array('one', 'two', 'three');
+    $cloned_variable = $this->getVarDumper()->captureVar($testData);
+    
+    // Later, when you want to render it. Note the second parameter is $seekPath; here we specify
+    // to only render the second array element (index 1). $html will therefore only contain 'two'.
+    $html = $this->getVarDumper()->renderCapturedVar($cloned_variable, array(1));
+
+## Text formatting
+
 An instance of `DebugBar\DataFormatter\DataFormatterInterface` is used by collectors to
-format data.
+format variables into a text-only format.
 
 The default instance is `DebugBar\DataFormatter\DataFormatter`. This can be modified
 using `DebugBar\DataCollector\DataCollector::setDefaultDataFormatter()`.
 
-You can use a custom formater for each collector using `DataCollector::setDataFormatter()`.
+You can use a custom formatter for each collector using `DataCollector::setDataFormatter()`.
+
+For general-purpose variable formatting, it's recommended to use the HTML variable dumper, described
+earlier.

--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -12,6 +12,7 @@ namespace DebugBar\DataCollector;
 
 use DebugBar\DataFormatter\DataFormatter;
 use DebugBar\DataFormatter\DataFormatterInterface;
+use DebugBar\DataFormatter\DebugBarVarDumper;
 
 /**
  * Abstract class for data collectors
@@ -19,8 +20,10 @@ use DebugBar\DataFormatter\DataFormatterInterface;
 abstract class DataCollector implements DataCollectorInterface
 {
     private static $defaultDataFormatter;
+    private static $defaultVarDumper;
 
     protected $dataFormater;
+    protected $varDumper;
 
     /**
      * Sets the default data formater instance used by all collectors subclassing this class
@@ -66,6 +69,55 @@ abstract class DataCollector implements DataCollectorInterface
             $this->dataFormater = self::getDefaultDataFormatter();
         }
         return $this->dataFormater;
+    }
+
+    /**
+     * Sets the default variable dumper used by all collectors subclassing this class
+     *
+     * @param DebugBarVarDumper $varDumper
+     */
+    public static function setDefaultVarDumper(DebugBarVarDumper $varDumper)
+    {
+        self::$defaultVarDumper = $varDumper;
+    }
+
+    /**
+     * Returns the default variable dumper
+     *
+     * @return DebugBarVarDumper
+     */
+    public static function getDefaultVarDumper()
+    {
+        if (self::$defaultVarDumper === null) {
+            self::$defaultVarDumper = new DebugBarVarDumper();
+        }
+        return self::$defaultVarDumper;
+    }
+
+    /**
+     * Sets the variable dumper instance used by this collector
+     *
+     * @param DebugBarVarDumper $varDumper
+     * @return $this
+     */
+    public function setVarDumper(DebugBarVarDumper $varDumper)
+    {
+        $this->varDumper = $varDumper;
+        return $this;
+    }
+
+    /**
+     * Gets the variable dumper instance used by this collector; note that collectors using this
+     * instance need to be sure to return the static assets provided by the variable dumper.
+     *
+     * @return DebugBarVarDumper
+     */
+    public function getVarDumper()
+    {
+        if ($this->varDumper === null) {
+            $this->varDumper = self::getDefaultVarDumper();
+        }
+        return $this->varDumper;
     }
 
     /**

--- a/src/DebugBar/DataFormatter/DebugBarVarDumper.php
+++ b/src/DebugBar/DataFormatter/DebugBarVarDumper.php
@@ -1,0 +1,425 @@
+<?php
+
+namespace DebugBar\DataFormatter;
+
+use DebugBar\DataCollector\AssetProvider;
+use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Cloner\Cursor;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\DumperInterface;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+
+/**
+ * Clones and renders variables in HTML format using the Symfony VarDumper component.
+ *
+ * Cloning is decoupled from rendering, so that dumper users can have the fastest possible cloning
+ * performance, while delaying rendering until it is actually needed.
+ */
+class DebugBarVarDumper implements AssetProvider
+{
+    protected static $defaultClonerOptions = array();
+
+    protected static $defaultDumperOptions = array(
+        'expanded_depth' => 0,
+        'styles' => array(
+            // NOTE:  'default' CSS is also specified in debugbar.css
+            'default' => 'word-wrap: break-word; white-space: pre-wrap; word-break: normal',
+            'num' => 'font-weight:bold; color:#1299DA',
+            'const' => 'font-weight:bold',
+            'str' => 'font-weight:bold; color:#3A9B26',
+            'note' => 'color:#1299DA',
+            'ref' => 'color:#7B7B7B',
+            'public' => 'color:#000000',
+            'protected' => 'color:#000000',
+            'private' => 'color:#000000',
+            'meta' => 'color:#B729D9',
+            'key' => 'color:#3A9B26',
+            'index' => 'color:#1299DA',
+            'ellipsis' => 'color:#A0A000',
+        ),
+    );
+
+    protected $clonerOptions;
+
+    protected $dumperOptions;
+
+    /** @var VarCloner */
+    protected $cloner;
+
+    /** @var DebugBarHtmlDumper */
+    protected $dumper;
+
+    /**
+     * Gets the VarCloner instance with configuration options set.
+     *
+     * @return VarCloner
+     */
+    protected function getCloner()
+    {
+        if (!$this->cloner) {
+            $clonerOptions = $this->getClonerOptions();
+            if (isset($clonerOptions['casters'])) {
+                $this->cloner = new VarCloner($clonerOptions['casters']);
+            } else {
+                $this->cloner = new VarCloner();
+            }
+            if (isset($clonerOptions['additional_casters'])) {
+                $this->cloner->addCasters($clonerOptions['additional_casters']);
+            }
+            if (isset($clonerOptions['max_items'])) {
+                $this->cloner->setMaxItems($clonerOptions['max_items']);
+            }
+            if (isset($clonerOptions['max_string'])) {
+                $this->cloner->setMaxString($clonerOptions['max_string']);
+            }
+            // setMinDepth was added to Symfony 3.4:
+            if (isset($clonerOptions['min_depth']) && method_exists($this->cloner, 'setMinDepth')) {
+                $this->cloner->setMinDepth($clonerOptions['min_depth']);
+            }
+        }
+        return $this->cloner;
+    }
+
+    /**
+     * Gets the DebugBarHtmlDumper instance with configuration options set.
+     *
+     * @return DebugBarHtmlDumper
+     */
+    protected function getDumper()
+    {
+        if (!$this->dumper) {
+            $this->dumper = new DebugBarHtmlDumper();
+            $dumperOptions = $this->getDumperOptions();
+            if (isset($dumperOptions['styles'])) {
+                $this->dumper->setStyles($dumperOptions['styles']);
+            }
+        }
+        return $this->dumper;
+    }
+
+    /**
+     * Gets the array of non-default VarCloner configuration options.
+     *
+     * @return array
+     */
+    public function getClonerOptions()
+    {
+        if ($this->clonerOptions === null) {
+            $this->clonerOptions = self::$defaultClonerOptions;
+        }
+        return $this->clonerOptions;
+    }
+
+    /**
+     * Merges an array of non-default VarCloner configuration options with the existing non-default
+     * options.
+     *
+     * Configuration options are:
+     *  - casters: a map of VarDumper Caster objects to use instead of the default casters.
+     *  - additional_casters: a map of VarDumper Caster objects to use in addition to the default
+     *    casters.
+     *  - max_items: maximum number of items to clone beyond the minimum depth.
+     *  - max_string: maximum string size
+     *  - min_depth: minimum tree depth to clone before counting items against the max_items limit.
+     *    (Requires Symfony 3.4; ignored on older versions.)
+     *
+     * @param array $options
+     */
+    public function mergeClonerOptions($options)
+    {
+        $this->clonerOptions = $options + $this->getClonerOptions();
+        $this->cloner = null;
+    }
+
+    /**
+     * Resets the array of non-default VarCloner configuration options without retaining any of the
+     * existing non-default options.
+     *
+     * Configuration options are:
+     *  - casters: a map of VarDumper Caster objects to use instead of the default casters.
+     *  - additional_casters: a map of VarDumper Caster objects to use in addition to the default
+     *    casters.
+     *  - max_items: maximum number of items to clone beyond the minimum depth.
+     *  - max_string: maximum string size
+     *  - min_depth: minimum tree depth to clone before counting items against the max_items limit.
+     *    (Requires Symfony 3.4; ignored on older versions.)
+     *
+     * @param array $options
+     */
+    public function resetClonerOptions($options = null)
+    {
+        $this->clonerOptions = ($options ?: array()) + self::$defaultClonerOptions;
+        $this->cloner = null;
+    }
+
+    /**
+     * Gets the array of non-default HtmlDumper configuration options.
+     *
+     * @return array
+     */
+    public function getDumperOptions()
+    {
+        if ($this->dumperOptions === null) {
+            $this->dumperOptions = self::$defaultDumperOptions;
+        }
+        return $this->dumperOptions;
+    }
+
+    /**
+     * Merges an array of non-default HtmlDumper configuration options with the existing non-default
+     * options.
+     *
+     * Configuration options are:
+     *  - styles: a map of CSS styles to include in the assets, as documented in
+     *    HtmlDumper::setStyles.
+     *  - expanded_depth: the tree depth to initially expand.
+     *    (Requires Symfony 3.2; ignored on older versions.)
+     *  - max_string: maximum string size.
+     *    (Requires Symfony 3.2; ignored on older versions.)
+     *  - file_link_format: link format for files; %f expanded to file and %l expanded to line
+     *    (Requires Symfony 3.2; ignored on older versions.)
+     *
+     * @param array $options
+     */
+    public function mergeDumperOptions($options)
+    {
+        $this->dumperOptions = $options + $this->getDumperOptions();
+        $this->dumper = null;
+    }
+
+    /**
+     * Resets the array of non-default HtmlDumper configuration options without retaining any of the
+     * existing non-default options.
+     *
+     * Configuration options are:
+     *  - styles: a map of CSS styles to include in the assets, as documented in
+     *    HtmlDumper::setStyles.
+     *  - expanded_depth: the tree depth to initially expand.
+     *    (Requires Symfony 3.2; ignored on older versions.)
+     *  - max_string: maximum string size.
+     *    (Requires Symfony 3.2; ignored on older versions.)
+     *  - file_link_format: link format for files; %f expanded to file and %l expanded to line
+     *    (Requires Symfony 3.2; ignored on older versions.)
+     *
+     * @param array $options
+     */
+    public function resetDumperOptions($options = null)
+    {
+        $this->dumperOptions = ($options ?: array()) + self::$defaultDumperOptions;
+        $this->dumper = null;
+    }
+
+    /**
+     * Captures the data from a variable and serializes it for later rendering.
+     *
+     * @param mixed $data The variable to capture.
+     * @return string Serialized variable data.
+     */
+    public function captureVar($data)
+    {
+        return serialize($this->getCloner()->cloneVar($data));
+    }
+
+    /**
+     * Gets the display options for the HTML dumper.
+     *
+     * @return array
+     */
+    protected function getDisplayOptions()
+    {
+        $displayOptions = array();
+        $dumperOptions = $this->getDumperOptions();
+        // Only used by Symfony 3.2 and newer:
+        if (isset($dumperOptions['expanded_depth'])) {
+            $displayOptions['maxDepth'] = $dumperOptions['expanded_depth'];
+        }
+        // Only used by Symfony 3.2 and newer:
+        if (isset($dumperOptions['max_string'])) {
+            $displayOptions['maxStringLength'] = $dumperOptions['max_string'];
+        }
+        // Only used by Symfony 3.2 and newer:
+        if (isset($dumperOptions['file_link_format'])) {
+            $displayOptions['fileLinkFormat'] = $dumperOptions['file_link_format'];
+        }
+        return $displayOptions;
+    }
+
+    /**
+     * Renders previously-captured data from captureVar to HTML and returns it as a string.
+     *
+     * @param string $capturedData Captured data from captureVar.
+     * @param array $seekPath Pass an array of keys to traverse if you only want to render a subset
+     *                        of the data.
+     * @return string HTML rendering of the variable.
+     */
+    public function renderCapturedVar($capturedData, $seekPath = array())
+    {
+        $data = unserialize($capturedData);
+        // The seek method was added in Symfony 3.2; emulate the behavior via SeekingData for older
+        // Symfony versions.
+        if (!method_exists($data, 'seek')) {
+            $data = new SeekingData($data->getRawData());
+        }
+
+        foreach ($seekPath as $key) {
+            $data = $data->seek($key);
+        }
+
+        return $this->dump($data);
+    }
+
+    /**
+     * Captures and renders the data from a variable to HTML and returns it as a string.
+     *
+     * @param mixed $data The variable to capture and render.
+     * @return string HTML rendering of the variable.
+     */
+    public function renderVar($data)
+    {
+        return $this->dump($this->getCloner()->cloneVar($data));
+    }
+
+    /**
+     * Returns assets required for rendering variables.
+     *
+     * @return array
+     */
+    public function getAssets() {
+        $dumper = $this->getDumper();
+        $dumper->setDumpHeader(null); // this will cause the default dump header to regenerate
+        return array(
+            'inline_head' => array(
+                'html_var_dumper' => $dumper->getDumpHeaderByDebugBar(),
+            ),
+        );
+    }
+
+    /**
+     * Helper function to dump a Data object to HTML.
+     *
+     * @param Data $data
+     * @return string
+     */
+    protected function dump(Data $data)
+    {
+        $dumper = $this->getDumper();
+        $output = fopen('php://memory', 'r+b');
+        $dumper->setOutput($output);
+        $dumper->setDumpHeader(''); // we don't actually want a dump header
+        // NOTE:  Symfony 3.2 added the third $extraDisplayOptions parameter.  Older versions will
+        // safely ignore it.
+        $dumper->dump($data, null, $this->getDisplayOptions());
+        $result = stream_get_contents($output, -1, 0);
+        fclose($output);
+        return $result;
+    }
+}
+
+/**
+ * We have to extend the base HtmlDumper class in order to get access to the protected-only
+ * getDumpHeader function.
+ */
+class DebugBarHtmlDumper extends HtmlDumper
+{
+    public function getDumpHeaderByDebugBar() {
+        // getDumpHeader is protected:
+        return $this->getDumpHeader();
+    }
+}
+
+/**
+ * This class backports the seek() function from Symfony 3.2 to older versions - up to v2.6.  The
+ * class should not be used with newer Symfony versions that provide the seek function, as it relies
+ * on a lot of undocumented functionality.
+ */
+class SeekingData extends Data
+{
+    // Because the class copies/pastes the seek() implementation from Symfony 3.2, we reproduce its
+    // copyright here; this class is subject to the following additional copyright:
+
+    /*
+     * Copyright (c) 2014-2017 Fabien Potencier
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is furnished
+     * to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in all
+     * copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+    private $position = 0;
+    private $key = 0;
+
+    /**
+     * Seeks to a specific key in nested data structures.
+     *
+     * @param string|int $key The key to seek to
+     *
+     * @return self|null A clone of $this of null if the key is not set
+     */
+    public function seek($key)
+    {
+        $thisData = $this->getRawData();
+        $item = $thisData[$this->position][$this->key];
+
+        if (!$item instanceof Stub || !$item->position) {
+            return;
+        }
+        $keys = array($key);
+
+        switch ($item->type) {
+            case Stub::TYPE_OBJECT:
+                $keys[] = "\0+\0".$key;
+                $keys[] = "\0*\0".$key;
+                $keys[] = "\0~\0".$key;
+                $keys[] = "\0$item->class\0$key";
+            case Stub::TYPE_ARRAY:
+            case Stub::TYPE_RESOURCE:
+                break;
+            default:
+                return;
+        }
+
+        $data = null;
+        $children = $thisData[$item->position];
+
+        foreach ($keys as $key) {
+            if (isset($children[$key]) || array_key_exists($key, $children)) {
+                $data = clone $this;
+                $data->key = $key;
+                $data->position = $item->position;
+                break;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dump(DumperInterface $dumper)
+    {
+        // Override the base class dump to use the position and key
+        $refs = array(0);
+        $class = new \ReflectionClass($this);
+        $dumpItem = $class->getMethod('dumpItem');
+        $dumpItem->setAccessible(true);
+        $data = $this->getRawData();
+        $args = array($dumper, new Cursor(), &$refs, $data[$this->position][$this->key]);
+        $dumpItem->invokeArgs($this, $args);
+    }
+}

--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -74,14 +74,21 @@ div.phpdebugbar input[type='text'], div.phpdebugbar input[type='password'] {
   margin: 0;
 }
 
-div.phpdebugbar code, div.phpdebugbar pre {
+div.phpdebugbar code, div.phpdebugbar pre, div.phpdebugbar samp {
   background: none;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   font-size: 1em;
-  color: #000;
   border: 0;
   padding: 0;
   margin: 0;
+}
+
+div.phpdebugbar code, div.phpdebugbar pre {
+  color: #000;
+}
+
+div.phpdebugbar pre.sf-dump {
+  color: #a0a000;
 }
 
 a.phpdebugbar-restore-btn {

--- a/tests/DebugBar/Tests/DataFormatter/DebugBarVarDumperTest.php
+++ b/tests/DebugBar/Tests/DataFormatter/DebugBarVarDumperTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace DebugBar\Tests\DataFormatter;
+
+use DebugBar\DataFormatter\DebugBarVarDumper;
+use DebugBar\Tests\DebugBarTestCase;
+
+class DebugBarVarDumperTest extends DebugBarTestCase
+{
+    const STYLE_STRING = 'SpecialStyleString';
+
+    private $testStyles = array(
+        'default' => self::STYLE_STRING,
+    );
+
+    public function testBasicFunctionality()
+    {
+        // Test that we can render a simple variable without dump headers
+        $d = new DebugBarVarDumper();
+        $d->mergeDumperOptions(array('styles' => $this->testStyles));
+        $out = $d->renderVar('magic');
+
+        $this->assertContains('magic', $out);
+        $this->assertNotContains(self::STYLE_STRING, $out); // make sure there's no dump header
+
+        // Test that we can capture a variable without rendering into a Data-type variable
+        $data = $d->captureVar('hello');
+        $this->assertContains('hello', $data);
+        $deserialized = unserialize($data);
+        $this->assertInstanceOf('Symfony\Component\VarDumper\Cloner\Data', $deserialized);
+
+        // Test that we can render the captured variable at a later time
+        $out = $d->renderCapturedVar($data);
+        $this->assertContains('hello', $out);
+        $this->assertNotContains(self::STYLE_STRING, $out); // make sure there's no dump header
+    }
+
+    public function testSeeking()
+    {
+        $testData = array(
+            'one',
+            array('two'),
+            'three',
+        );
+        $d = new DebugBarVarDumper();
+        $data = $d->captureVar($testData);
+
+        // seek depth of 1
+        $out = $d->renderCapturedVar($data, array(1));
+        $this->assertNotContains('one', $out);
+        $this->assertContains('array', $out);
+        $this->assertContains('two', $out);
+        $this->assertNotContains('three', $out);
+
+        // seek depth of 2
+        $out = $d->renderCapturedVar($data, array(1, 0));
+        $this->assertNotContains('one', $out);
+        $this->assertNotContains('array', $out);
+        $this->assertContains('two', $out);
+        $this->assertNotContains('three', $out);
+    }
+
+    public function testAssetProvider()
+    {
+        $d = new DebugBarVarDumper();
+        $d->mergeDumperOptions(array('styles' => $this->testStyles));
+        $assets = $d->getAssets();
+        $this->assertArrayHasKey('inline_head', $assets);
+        $this->assertCount(1, $assets);
+
+        $inlineHead = $assets['inline_head'];
+        $this->assertArrayHasKey('html_var_dumper', $inlineHead);
+        $this->assertCount(1, $inlineHead);
+
+        $assetText = $inlineHead['html_var_dumper'];
+        $this->assertContains(self::STYLE_STRING, $assetText);
+    }
+
+    public function testBasicOptionOperations()
+    {
+        // Test basic get/merge/reset functionality for cloner
+        $d = new DebugBarVarDumper();
+        $options = $d->getClonerOptions();
+        $this->assertEmpty($options);
+
+        $d->mergeClonerOptions(array(
+            'max_items' => 5,
+        ));
+        $d->mergeClonerOptions(array(
+            'max_string' => 4,
+        ));
+        $d->mergeClonerOptions(array(
+            'max_items' => 3,
+        ));
+        $options = $d->getClonerOptions();
+        $this->assertEquals(array(
+            'max_items' => 3,
+            'max_string' => 4,
+        ), $options);
+
+        $d->resetClonerOptions(array(
+            'min_depth' => 2,
+        ));
+        $options = $d->getClonerOptions();
+        $this->assertEquals(array(
+            'min_depth' => 2,
+        ), $options);
+
+        // Test basic get/merge/reset functionality for dumper
+        $options = $d->getDumperOptions();
+        $this->assertContains('styles', $options);
+        $this->assertArrayHasKey('const', $options['styles']);
+        $this->assertContains('expanded_depth', $options);
+        $this->assertEquals(0, $options['expanded_depth']);
+        $this->assertCount(2, $options);
+
+        $d->mergeDumperOptions(array(
+            'styles' => $this->testStyles,
+        ));
+        $d->mergeDumperOptions(array(
+            'max_string' => 7,
+        ));
+        $options = $d->getDumperOptions();
+        $this->assertEquals(array(
+            'max_string' => 7,
+            'styles' => $this->testStyles,
+            'expanded_depth' => 0,
+        ), $options);
+
+        $d->resetDumperOptions(array(
+            'styles' => $this->testStyles,
+        ));
+        $options = $d->getDumperOptions();
+        $this->assertEquals(array(
+            'styles' => $this->testStyles,
+            'expanded_depth' => 0,
+        ), $options);
+    }
+
+    public function testClonerOptions()
+    {
+        // Test the actual operation of the cloner options
+        $d = new DebugBarVarDumper();
+
+        // Test that the 'casters' option can remove default casters
+        $testData = function() {};
+        $d->resetClonerOptions();
+        $this->assertContains('DebugBarVarDumperTest.php', $d->renderVar($testData));
+
+        $d->resetClonerOptions(array(
+            'casters' => array(),
+        ));
+        $this->assertNotContains('DebugBarVarDumperTest.php', $d->renderVar($testData));
+
+        // Test that the 'additional_casters' option can add new casters
+        $testData = function() {};
+        $d->resetClonerOptions();
+        $this->assertContains('DebugBarVarDumperTest.php', $d->renderVar($testData));
+
+        $d->resetClonerOptions(array(
+            'casters' => array(),
+            'additional_casters' => array('Closure' => 'Symfony\Component\VarDumper\Caster\ReflectionCaster::castClosure'),
+        ));
+        $this->assertContains('DebugBarVarDumperTest.php', $d->renderVar($testData));
+
+        // Test 'max_items'
+        $testData = array(array('one', 'two', 'three', 'four', 'five'));
+        $d->resetClonerOptions();
+        $out = $d->renderVar($testData);
+        foreach ($testData[0] as $search) {
+            $this->assertContains($search, $out);
+        }
+
+        $d->resetClonerOptions(array(
+            'max_items' => 3,
+        ));
+        $out = $d->renderVar($testData);
+        $this->assertContains('one', $out);
+        $this->assertContains('two', $out);
+        $this->assertContains('three', $out);
+        $this->assertNotContains('four', $out);
+        $this->assertNotContains('five', $out);
+
+        // Test 'max_string'
+        $testData = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $d->resetClonerOptions();
+        $this->assertContains($testData, $d->renderVar($testData));
+
+        $d->resetClonerOptions(array(
+            'max_string' => 10,
+        ));
+        $out = $d->renderVar($testData);
+        $this->assertContains('ABCDEFGHIJ', $out);
+        $this->assertNotContains('ABCDEFGHIJK', $out);
+
+        // Test 'min_depth' if we are on a Symfony version that supports it
+        if (method_exists('Symfony\Component\VarDumper\Cloner\AbstractCloner', 'setMinDepth')) {
+            $testData = array('one', 'two', 'three', 'four', 'five');
+            $d->resetClonerOptions(array(
+                'max_items' => 3,
+            ));
+            $out = $d->renderVar($testData);
+            foreach ($testData as $search) {
+                $this->assertContains($search, $out);
+            }
+
+            $d->resetClonerOptions(array(
+                'min_depth' => 0,
+                'max_items' => 3,
+            ));
+            $out = $d->renderVar($testData);
+            $this->assertContains('one', $out);
+            $this->assertContains('two', $out);
+            $this->assertContains('three', $out);
+            $this->assertNotContains('four', $out);
+            $this->assertNotContains('five', $out);
+        }
+    }
+
+    public function testDumperOptions()
+    {
+        // Test the actual operation of the dumper options
+        $d = new DebugBarVarDumper();
+
+        // Test that the 'styles' option affects assets
+        $d->resetDumperOptions();
+        $assets = $d->getAssets();
+        $this->assertNotContains(self::STYLE_STRING, $assets['inline_head']['html_var_dumper']);
+
+        $d->resetDumperOptions(array('styles' => $this->testStyles));
+        $assets = $d->getAssets();
+        $this->assertContains(self::STYLE_STRING, $assets['inline_head']['html_var_dumper']);
+
+        // The next tests require changes in Symfony 3.2:
+        $dumpMethod = new \ReflectionMethod('Symfony\Component\VarDumper\Dumper\HtmlDumper', 'dump');
+        if ($dumpMethod->getNumberOfParameters() >= 3) {
+            // Test that the 'expanded_depth' option affects output
+            $d->resetDumperOptions(array('expanded_depth' => 123321));
+            $out = $d->renderVar(true);
+            $this->assertContains('123321', $out);
+
+            // Test that the 'max_string' option affects output
+            $d->resetDumperOptions(array('max_string' => 321123));
+            $out = $d->renderVar(true);
+            $this->assertContains('321123', $out);
+
+            // Test that the 'file_link_format' option affects output
+            $d->resetDumperOptions(array('file_link_format' => 'fmt%ftest'));
+            $out = $d->renderVar(function() {});
+            $this->assertContains('DebugBarVarDumperTest.phptest', $out);
+        }
+    }
+}


### PR DESCRIPTION
The Symfony VarDumper component includes an `HtmlDumper` that dumps variables in a rich HTML format that allows for expanding and collapsing individual tree nodes in the dumped variable.  This makes it much more practical to navigate large/deep variables that have been dumped.

`DebugBarVarDumper` provides a Debug Bar-friendly wrapper around the VarDumper component.  It’s intended as an alternative to `DataFormatter::formatVar` to enable this rich HTML interface.  It provides for:

* Debug Bar-friendly styles for the VarDumper HTML.

* Implements `AssetProvider` for returning VarDumper static assets (requires users of `JavascriptRenderer` to support inline assets).

* Simplifies/wraps `VarCloner` and `HtmlDumper` function calls for cloning and dumping variables in a Debug Bar environment.  VarDumper was originally written/targeted to be a replacement for `var_dump`, so the default behavior of `HtmlDumper` echoing static assets and variable dumps directly to the page output isn’t really appropriate.  Furthermore, we must contend with several different Symfony versions going back to v2.6.0.  This class provides a friendly wrapper over all of that.

I have tested this with these Symfony versions:

* v2.6.0
* v2.7.0
* v2.8.0
* v3.0.0
* v3.1.0
* v3.2.0
* v3.3.0

All seem to work fine, with graceful degradation as needed.

Furthermore, the class is ready to take advantage of new features that I added and are upcoming in Symfony v3.4:

* setMinDepth: https://github.com/symfony/symfony/pull/23515
  This feature will be valuable for the upcoming BacktraceCollector.

Screenshots of how this looks with some of the collectors.  After this PR is merged, I'll submit more pull requests to enable these collectors to integrate with this new feature.

Request collector:
![screen shot 2017-07-18 at 1 44 22 pm](https://user-images.githubusercontent.com/22308682/28338916-3d0a1198-6bbf-11e7-9aea-9ea13d1c31eb.png)

Rich variable dumping in the message collector:
![screen shot 2017-07-18 at 1 46 39 pm](https://user-images.githubusercontent.com/22308682/28339014-9567b4c6-6bbf-11e7-979b-de8bf3966e4f.png)

Upcoming backtrace collector:
![screen shot 2017-07-18 at 1 47 28 pm](https://user-images.githubusercontent.com/22308682/28339039-b1518068-6bbf-11e7-8f32-53a8998cabf6.png)
