### PR TITLE
Update MessagesCollector to support HTML var dumping

### DIFF
--- a/docs/base_collectors.md
+++ b/docs/base_collectors.md
@@ -6,9 +6,18 @@ Collectors provided in the `DebugBar\DataCollector` namespace.
 ## Messages
 
 Provides a way to log messages (compatible with [PSR-3 logger](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)).
+You can call the `useHtmlVarDumper()` function to use VarDumper's interactive HTML dumper for
+interactively rendering complex variables.  If you do that, you must properly render
+[inline assets](rendering.html#assets) when rendering the debug bar in addition to the normal js/css
+static assets.
 
-    $debugbar->addCollector(new DebugBar\DataCollector\MessagesCollector());
+    $c = new DebugBar\DataCollector\MessagesCollector();
+    $c->useHtmlVarDumper(); // Enables prettier dumps of objects; requires inline assets
+    $debugbar->addCollector($c);
+
     $debugbar['messages']->info('hello world');
+    $complicated_variable = array(1, 2, array(3, 4));
+    $debugbar['messages']->info($complicated_variable); // interactive HTML variable dumping
 
 You can have multiple messages collector by naming them:
 

--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -73,6 +73,9 @@ div.phpdebugbar-widgets-messages {
     font-size: 11px;
     color: red;
   }
+  div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item pre.sf-dump {
+    display: inline;
+  }
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector,
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-label {
     float: right;

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -295,33 +295,37 @@ if (typeof(PhpDebugBar) == 'undefined') {
             var self = this;
 
             this.$list = new ListWidget({ itemRenderer: function(li, value) {
-                var m = value.message;
-                if (m.length > 100) {
-                    m = m.substr(0, 100) + "...";
-                }
-
-                var val = $('<span />').addClass(csscls('value')).text(m).appendTo(li);
-                if (!value.is_string || value.message.length > 100) {
-                    var prettyVal = value.message;
-                    if (!value.is_string) {
-                        prettyVal = null;
+                if (value.message_html) {
+                    var val = $('<span />').addClass(csscls('value')).html(value.message_html).appendTo(li);
+                } else {
+                    var m = value.message;
+                    if (m.length > 100) {
+                        m = m.substr(0, 100) + "...";
                     }
-                    li.css('cursor', 'pointer').click(function() {
-                        if (val.hasClass(csscls('pretty'))) {
-                            val.text(m).removeClass(csscls('pretty'));
-                        } else {
-                            prettyVal = prettyVal || createCodeBlock(value.message, 'php');
-                            val.addClass(csscls('pretty')).empty().append(prettyVal);
+
+                    var val = $('<span />').addClass(csscls('value')).text(m).appendTo(li);
+                    if (!value.is_string || value.message.length > 100) {
+                        var prettyVal = value.message;
+                        if (!value.is_string) {
+                            prettyVal = null;
                         }
-                    });
+                        li.css('cursor', 'pointer').click(function () {
+                            if (val.hasClass(csscls('pretty'))) {
+                                val.text(m).removeClass(csscls('pretty'));
+                            } else {
+                                prettyVal = prettyVal || createCodeBlock(value.message, 'php');
+                                val.addClass(csscls('pretty')).empty().append(prettyVal);
+                            }
+                        });
+                    }
                 }
 
+                if (value.collector) {
+                    $('<span />').addClass(csscls('collector')).text(value.collector).prependTo(li);
+                }
                 if (value.label) {
                     val.addClass(csscls(value.label));
-                    $('<span />').addClass(csscls('label')).text(value.label).appendTo(li);
-                }
-                if (value.collector) {
-                    $('<span />').addClass(csscls('collector')).text(value.collector).appendTo(li);
+                    $('<span />').addClass(csscls('label')).text(value.label).prependTo(li);
                 }
             }});
 

--- a/tests/DebugBar/Tests/DataCollector/MessagesCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/MessagesCollectorTest.php
@@ -38,4 +38,46 @@ class MessagesCollectorTest extends DebugBarTestCase
         $this->assertEquals(1, $data['count']);
         $this->assertEquals($c->getMessages(), $data['messages']);
     }
+
+    public function testAssets()
+    {
+        $c = new MessagesCollector();
+        $this->assertEmpty($c->getAssets());
+
+        $c->useHtmlVarDumper();
+        $this->assertNotEmpty($c->getAssets());
+    }
+
+    public function testHtmlMessages()
+    {
+        $var = array('one', 'two');
+
+        $c = new MessagesCollector();
+        $this->assertFalse($c->isHtmlVarDumperUsed());
+        $c->addMessage($var);
+        $data = $c->collect();
+        $message_text = $data['messages'][0]['message'];
+        $this->assertContains('array', $message_text);
+        $this->assertContains('one', $message_text);
+        $this->assertContains('two', $message_text);
+        $this->assertNotContains('span', $message_text);
+        $this->assertNull($data['messages'][0]['message_html']);
+
+        $c = new MessagesCollector();
+        $c->useHtmlVarDumper();
+        $this->assertTrue($c->isHtmlVarDumperUsed());
+        $c->addMessage($var);
+        $data = $c->collect();
+        $message_text = $data['messages'][0]['message'];
+        $this->assertContains('array', $message_text);
+        $this->assertContains('one', $message_text);
+        $this->assertContains('two', $message_text);
+        $this->assertNotContains('span', $message_text);
+        $message_html = $data['messages'][0]['message_html'];
+        $this->assertContains('array', $message_html);
+        $this->assertContains('one', $message_html);
+        $this->assertContains('two', $message_html);
+        $this->assertContains('span', $message_html);
+
+    }
 }


### PR DESCRIPTION
Use the new `DebugBarVarDumper` class to support dumping variables in interactive collapsible HTML; the new `useHtmlVarDumper()` function will enable this.

Since this will require users to handle the new inline assets provided by the `JavascriptRenderer`, make this dumping format optional and default to the old behavior for now.

<img width="534" alt="screen shot 2017-07-20 at 2 13 16 pm" src="https://user-images.githubusercontent.com/22308682/28440820-caa5a082-6d5c-11e7-97d8-0f195ee07d7e.png">
