### PR TITLE
Fix broken top-level style name

### DIFF
--- a/src/DebugBar/DataFormatter/DebugBarVarDumper.php
+++ b/src/DebugBar/DataFormatter/DebugBarVarDumper.php
@@ -45,7 +45,7 @@ class DebugBarVarDumper implements AssetProvider
     /** @var VarCloner */
     protected $cloner;
 
-    /** @var Debu */
+    /** @var DebugBarHtmlDumper */
     protected $dumper;
 
     /**

--- a/src/DebugBar/DataFormatter/VarDumper/DebugBarHtmlDumper.php
+++ b/src/DebugBar/DataFormatter/VarDumper/DebugBarHtmlDumper.php
@@ -12,6 +12,6 @@ class DebugBarHtmlDumper extends HtmlDumper
 {
     public function getDumpHeaderByDebugBar() {
         // getDumpHeader is protected:
-        return str_replace('pre.sf-dump', '.debugbar pre.sf-dump', $this->getDumpHeader());
+        return str_replace('pre.sf-dump', '.phpdebugbar pre.sf-dump', $this->getDumpHeader());
     }
 }


### PR DESCRIPTION
The top-level debug bar style is `phpdebugbar` not `debugbar`.  This was preventing rendered HtmlDumper dumps from styling correctly.

Screenshot of the broken behavior this pull request fixes:

![screen shot 2017-07-27 at 6 20 27 pm](https://user-images.githubusercontent.com/22308682/28698435-5e10667c-72f8-11e7-85e5-884c27fdbd74.png)
