### PR TITLE
Added sorting for RedisStorage

### DIFF
--- a/src/DebugBar/Storage/RedisStorage.php
+++ b/src/DebugBar/Storage/RedisStorage.php
@@ -59,6 +59,11 @@ class RedisStorage implements StorageInterface
                 }
             }
         }
+        
+        usort($results, function ($a, $b) {
+            return $a['utime'] < $b['utime'];
+        });
+        
         return array_slice($results, $offset, $max);
     }
 


### PR DESCRIPTION
Debugbar output with RedisStorage and Redis 3.0.6 (can't test others) now comes in random order. Likely
sorted by hash. The patch solves the problem. Code is reworked to be close to a similar one in FileStorage.