### PR TITLE
Fix for memory overrun in RedisStorage

### DIFF
--- a/src/DebugBar/Storage/RedisStorage.php
+++ b/src/DebugBar/Storage/RedisStorage.php
@@ -51,8 +51,8 @@ class RedisStorage implements StorageInterface
     public function find(array $filters = array(), $max = 20, $offset = 0)
     {
         $results = array();
-        foreach ($this->redis->hgetall($this->hash) as $id => $data) {
-            if ($data = unserialize($data)) {
+        foreach ($this->redis->hkeys($this->hash) as $id) {
+            if ($data = $this->get($id)) {
                 $meta = $data['__meta'];
                 if ($this->filter($meta, $filters)) {
                     $results[] = $meta;


### PR DESCRIPTION
Patch increases number of possible count of records loaded from Redis DB by picking them one by one instead of bulk retrieving. HGETALL causes FatalErrorException with "Allowed memory size of 134217728 bytes exhausted" on around of 2500 records, Patch leads to a little speedup even on small amount or records (about 3-4%) and also allows to work on 1500+ records as well.
Problem is described in barryvdh/laravel-debugbar#417