### PR TITLE
Fix remove square bracket array declaration for PHP 5.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 php:
   - 5.3
   - 5.4

--- a/src/DebugBar/DataCollector/PhpInfoCollector.php
+++ b/src/DebugBar/DataCollector/PhpInfoCollector.php
@@ -39,14 +39,13 @@ class PhpInfoCollector extends DataCollector implements Renderable
      */
     public function getWidgets()
     {
-        return [
-            "php_version" => [
+        return array(
+            "php_version" => array(
                 "icon" => "code",
                 "tooltip" => "Version",
                 "map" => "php.version",
                 "default" => ""
-            ],
-        ];
+            ),
+        );
     }
-
 }


### PR DESCRIPTION
Commit 1fd5af22 introduces array syntax that is incompatible with PHP 5.3, which this package still states support for. This PR is a patch to undo this.

Also switching to precise on Travis (default is quickly becoming trusty) to ensure PHP 5.3 compatibility.

I'd suggest releasing a new semver compatible version that removes PHP 5.3-5.5 support at some stage.