### PR TITLE
Feature/twig profiler

### DIFF
--- a/docs/bridge_collectors.md
+++ b/docs/bridge_collectors.md
@@ -113,3 +113,12 @@ You need to inject the root-`Twig_Profiler_Profile` into the collector:
     $env->addExtension(new Twig_Extension_Profiler($profile));
     $debugbar->addCollector(new DebugBar\Bridge\TwigProfileCollector($profile));
 
+You can optionally use `DebugBar\Bridge\Twig\TimeableTwigExtensionProfiler` in place of
+`Twig_Extension_Profiler` so render operation can be measured.
+
+    $loader = new Twig_Loader_Filesystem('.');
+    $env = new Twig_Environment($loader);
+    $profile = new Twig_Profiler_Profile();
+    $env->addExtension(new TimeableTwigExtensionProfiler($profile, $debugbar['time']));
+    $debugbar->addCollector(new DebugBar\Bridge\TwigProfileCollector($profile));
+

--- a/docs/bridge_collectors.md
+++ b/docs/bridge_collectors.md
@@ -99,3 +99,17 @@ You need to wrap your `Twig_Environment` object into a `DebugBar\Bridge\Twig\Tra
 
 You can provide a `DebugBar\DataCollector\TimeDataCollector` as the second argument of
 `TraceableTwigEnvironment` so render operation can be measured.
+
+## Twig (Profiler)
+
+An alternative to `DebugBar\Bridge\Twig\TwigCollector` for newer versions of twig.
+This collector uses the class `Twig_Extension_Profiler` to collect info about rendered
+templates, blocks and macros.
+You need to inject the root-`Twig_Profiler_Profile` into the collector:
+
+    $loader = new Twig_Loader_Filesystem('.');
+    $env = new Twig_Environment($loader);
+    $profile = new Twig_Profiler_Profile();
+    $env->addExtension(new Twig_Extension_Profiler($profile));
+    $debugbar->addCollector(new DebugBar\Bridge\TwigProfileCollector($profile));
+

--- a/src/DebugBar/Bridge/Twig/TimeableTwigExtensionProfiler.php
+++ b/src/DebugBar/Bridge/Twig/TimeableTwigExtensionProfiler.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * This file is part of the DebugBar package.
+ *
+ * (c) 2017 Tim Riemenschneider
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DebugBar\Bridge\Twig;
+
+use DebugBar\DataCollector\TimeDataCollector;
+use Twig_Profiler_Profile;
+
+/**
+ * Class TimeableTwigExtensionProfiler
+ *
+ * Extends Twig_Extension_Profiler to add rendering times to the TimeDataCollector
+ *
+ * @package DebugBar\Bridge\Twig
+ */
+class TimeableTwigExtensionProfiler extends \Twig_Extension_Profiler
+{
+    /**
+     * @var \DebugBar\DataCollector\TimeDataCollector
+     */
+    private $timeDataCollector;
+
+    /**
+     * @param \DebugBar\DataCollector\TimeDataCollector $timeDataCollector
+     */
+    public function setTimeDataCollector(TimeDataCollector $timeDataCollector)
+    {
+        $this->timeDataCollector = $timeDataCollector;
+    }
+
+    public function __construct(\Twig_Profiler_Profile $profile, TimeDataCollector $timeDataCollector = null)
+    {
+        parent::__construct($profile);
+
+        $this->timeDataCollector = $timeDataCollector;
+    }
+
+    public function enter(Twig_Profiler_Profile $profile)
+    {
+        if ($this->timeDataCollector && $profile->isTemplate()) {
+            $this->timeDataCollector->startMeasure($profile->getName(), 'template ' . $profile->getName());
+        }
+        parent::enter($profile);
+    }
+
+    public function leave(Twig_Profiler_Profile $profile)
+    {
+        parent::leave($profile);
+        if ($this->timeDataCollector && $profile->isTemplate()) {
+            $this->timeDataCollector->stopMeasure($profile->getName());
+        }
+    }
+}

--- a/src/DebugBar/Bridge/TwigProfileCollector.php
+++ b/src/DebugBar/Bridge/TwigProfileCollector.php
@@ -1,0 +1,164 @@
+<?php
+/*
+ * This file is part of the DebugBar package.
+ *
+ * (c) 2017 Tim Riemenschneider
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DebugBar\Bridge;
+
+use DebugBar\DataCollector\AssetProvider;
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
+
+/**
+ * Collects data about rendered templates
+ *
+ * http://twig.sensiolabs.org/
+ *
+ * A Twig_Extension_Profiler should be added to your Twig_Environment
+ * The root-Twig_Profiler_Profile-object should then be injected into this collector
+ *
+ * @see \Twig_Extension_Profiler, \Twig_Profiler_Profile
+ *
+ * <code>
+ * $env = new Twig_Environment($loader); // Or from a PSR11-container
+ * $profile = new Twig_Profiler_Profile();
+ * $env->addExtension(new Twig_Extension_Profile($profile));
+ * $debugbar->addCollector(new TwigProfileCollector($profile));
+ * </code>
+ */
+class TwigProfileCollector extends DataCollector implements Renderable, AssetProvider
+{
+    /**
+     * @var \Twig_Profiler_Profile
+     */
+    private $profile;
+    /** @var int */
+    private $templateCount;
+    /** @var int */
+    private $blockCount;
+    /** @var int */
+    private $macroCount;
+    /**
+     * @var array[] {
+     * @var string $name
+     * @var int    $render_time
+     * @var string $render_time_str
+     * @var string $memory_str
+     * }
+     */
+    private $templates;
+
+    /**
+     * TwigProfileCollector constructor.
+     *
+     * @param \Twig_Profiler_Profile $profile
+     */
+    public function __construct(\Twig_Profiler_Profile $profile)
+    {
+        $this->profile = $profile;
+    }
+
+    /**
+     * Returns a hash where keys are control names and their values
+     * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+     *
+     * @return array
+     */
+    public function getWidgets()
+    {
+        return array(
+            'twig'       => array(
+                'icon'    => 'leaf',
+                'widget'  => 'PhpDebugBar.Widgets.TemplatesWidget',
+                'map'     => 'twig',
+                'default' => json_encode(array('templates' => array())),
+            ),
+            'twig:badge' => array(
+                'map'     => 'twig.badge',
+                'default' => 0,
+            ),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getAssets()
+    {
+        return array(
+            'css' => 'widgets/templates/widget.css',
+            'js'  => 'widgets/templates/widget.js',
+        );
+    }
+
+    /**
+     * Called by the DebugBar when data needs to be collected
+     *
+     * @return array Collected data
+     */
+    function collect()
+    {
+        $this->templateCount = $this->blockCount = $this->macroCount = 0;
+        $this->templates     = array();
+        $this->computeData($this->profile);
+
+        return array(
+            'nb_templates'                => $this->templateCount,
+            'nb_blocks'                   => $this->blockCount,
+            'nb_macros'                   => $this->macroCount,
+            'templates'                   => $this->templates,
+            'accumulated_render_time'     => $this->profile->getDuration(),
+            'accumulated_render_time_str' => $this->getDataFormatter()->formatDuration($this->profile->getDuration()),
+            'memory_usage_str'            => $this->getDataFormatter()->formatBytes($this->profile->getMemoryUsage()),
+            'callgraph'                   => $this->getHtmlCallGraph(),
+            'badge'                       => implode(
+                '/',
+                array(
+                    $this->templateCount,
+                    $this->blockCount,
+                    $this->macroCount,
+                )
+            ),
+        );
+    }
+
+    /**
+     * Returns the unique name of the collector
+     *
+     * @return string
+     */
+    function getName()
+    {
+        return 'twig';
+    }
+
+    public function getHtmlCallGraph()
+    {
+        $dumper = new \Twig_Profiler_Dumper_Html();
+
+        return $dumper->dump($this->profile);
+    }
+
+    private function computeData(\Twig_Profiler_Profile $profile)
+    {
+        $this->templateCount += ($profile->isTemplate() ? 1 : 0);
+        $this->blockCount    += ($profile->isBlock() ? 1 : 0);
+        $this->macroCount    += ($profile->isMacro() ? 1 : 0);
+        if ($profile->isTemplate()) {
+            $this->templates[] = array(
+                'name'            => $profile->getName(),
+                'render_time'     => $profile->getDuration(),
+                'render_time_str' => $this->getDataFormatter()->formatDuration($profile->getDuration()),
+                'memory_str'      => $this->getDataFormatter()->formatBytes($profile->getMemoryUsage()),
+            );
+        }
+        foreach ($profile as $p) {
+            $this->computeData($p);
+        }
+    }
+}

--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -24,6 +24,9 @@ abstract class DataCollector implements DataCollectorInterface
 
     protected $dataFormater;
     protected $varDumper;
+    protected $xdebugLinkTemplate = '';
+    protected $xdebugShouldUseAjax = false;
+    protected $xdebugReplacements = array();
 
     /**
      * Sets the default data formater instance used by all collectors subclassing this class
@@ -74,12 +77,23 @@ abstract class DataCollector implements DataCollectorInterface
     /**
      * Get an Xdebug Link to a file
      *
-     * @return string|null
+     * @param string $file
+     * @param int    $line
+     *
+     * @return array {
+     * @var string   $url
+     * @var bool     $ajax should be used to open the url instead of a normal links
+     * }
      */
     public function getXdebugLink($file, $line = 1)
     {
-        if (ini_get('xdebug.file_link_format') || extension_loaded('xdebug')) {
-            return e(str_replace(array('%f', '%l'), array($file, $line), ini_get('xdebug.file_link_format')));
+        if (count($this->xdebugReplacements)) {
+            $file = strtr($file, $this->xdebugReplacements);
+        }
+
+        $url = strtr($this->getXdebugLinkTemplate(), ['%f' => $file, '%l' => $line]);
+        if ($url) {
+            return ['url' => $url, 'ajax' => $this->getXdebugShouldUseAjax()];
         }
     }
   
@@ -154,5 +168,67 @@ abstract class DataCollector implements DataCollectorInterface
     public function formatBytes($size, $precision = 2)
     {
         return $this->getDataFormatter()->formatBytes($size, $precision);
+    }
+
+    /**
+     * @return string
+     */
+    public function getXdebugLinkTemplate()
+    {
+        if (empty($this->xdebugLinkTemplate) && !empty(ini_get('xdebug.file_link_format'))) {
+            $this->xdebugLinkTemplate = ini_get('xdebug.file_link_format');
+        }
+
+        return $this->xdebugLinkTemplate;
+    }
+
+    /**
+     * @param string $xdebugLinkTemplate
+     * @param bool $shouldUseAjax
+     */
+    public function setXdebugLinkTemplate($xdebugLinkTemplate, $shouldUseAjax = false)
+    {
+        if ($xdebugLinkTemplate === 'idea') {
+            $this->xdebugLinkTemplate  = 'http://localhost:63342/api/file/?file=%f&line=%l';
+            $this->xdebugShouldUseAjax = true;
+        } else {
+            $this->xdebugLinkTemplate  = $xdebugLinkTemplate;
+            $this->xdebugShouldUseAjax = $shouldUseAjax;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function getXdebugShouldUseAjax()
+    {
+        return $this->xdebugShouldUseAjax;
+    }
+
+    /**
+     * returns an array of filename-replacements
+     *
+     * this is useful f.e. when using vagrant or remote servers,
+     * where the path of the file is different between server and
+     * development environment
+     *
+     * @return array key-value-pairs of replacements, key = path on server, value = replacement
+     */
+    public function getXdebugReplacements()
+    {
+        return $this->xdebugReplacements;
+    }
+
+    /**
+     * @param array $xdebugReplacements
+     */
+    public function setXdebugReplacements($xdebugReplacements)
+    {
+        $this->xdebugReplacements = $xdebugReplacements;
+    }
+
+    public function setXdebugReplacement($serverPath, $replacement)
+    {
+        $this->xdebugReplacements[$serverPath] = $replacement;
     }
 }

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -108,7 +108,8 @@ class ExceptionsCollector extends DataCollector implements Renderable
             'code' => $e->getCode(),
             'file' => $filePath,
             'line' => $e->getLine(),
-            'surrounding_lines' => $lines
+            'surrounding_lines' => $lines,
+            'xdebug_link' => $this->getXdebugLink($filePath, $e->getLine())
         );
     }
 

--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -247,3 +247,15 @@ div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item {
     border: 1px solid #ddd;
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   }
+
+div.phpdebugbar-widgets-exceptions a.phpdebugbar-widgets-editor-link:before {
+  font-family: PhpDebugbarFontAwesome;
+  margin-right: 4px;
+  font-size: 12px;
+  font-style: normal;
+}
+
+div.phpdebugbar-widgets-exceptions a.phpdebugbar-widgets-editor-link:before {
+  content: "\f08e";
+  margin-left: 4px;
+}

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -490,7 +490,17 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.$list = new ListWidget({ itemRenderer: function(li, e) {
                 $('<span />').addClass(csscls('message')).text(e.message).appendTo(li);
                 if (e.file) {
-                    $('<span />').addClass(csscls('filename')).text(e.file + "#" + e.line).appendTo(li);
+                    var header = $('<span />').addClass(csscls('filename')).text(e.file + "#" + e.line);
+                    if (e.xdebug_link) {
+                        if (e.xdebug_link.ajax) {
+                            $('<a title="' + e.xdebug_link.url + '"></a>').on('click', function () {
+                                $.ajax(e.xdebug_link.url);
+                            }).addClass(csscls('editor-link')).appendTo(header);
+                        } else {
+                            $('<a href="' + e.xdebug_link.url + '"></a>').addClass(csscls('editor-link')).appendTo(header);
+                        }
+                    }
+                    header.appendTo(li);
                 }
                 if (e.type) {
                     $('<span />').addClass(csscls('type')).text(e.type).appendTo(li);

--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -18,7 +18,7 @@
             this.$list = new  PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, tpl) {
                 $('<span />').addClass(csscls('name')).text(tpl.name).appendTo(li);
 
-                if (typeof tpl.xdebug_link != 'undefined') {
+                if (typeof tpl.xdebug_link !== 'undefined') {
                     $('<a href="' + tpl.xdebug_link + '"></a>').addClass(csscls('editor-link')).appendTo(li);
                 }
                 if (tpl.render_time_str) {
@@ -51,19 +51,30 @@
                 }
             }});
             this.$list.$el.appendTo(this.$el);
+            this.$callgraph = $('<div />').addClass(csscls('callgraph')).appendTo(this.$el);
 
             this.bindAttr('data', function(data) {
                 this.$list.set('data', data.templates);
                 this.$status.empty();
+                this.$callgraph.empty();
 
                 var sentence = data.sentence || "templates were rendered";
-                $('<span />').text(data.templates.length + " " + sentence).appendTo(this.$status);
+                $('<span />').text(data.nb_templates + " " + sentence).appendTo(this.$status);
 
                 if (data.accumulated_render_time_str) {
                     this.$status.append($('<span title="Accumulated render time" />').addClass(csscls('render-time')).text(data.accumulated_render_time_str));
                 }
                 if (data.memory_usage_str) {
                     this.$status.append($('<span title="Memory usage" />').addClass(csscls('memory')).text(data.memory_usage_str));
+                }
+                if (data.nb_blocks > 0) {
+                    $('<div />').text(data.nb_blocks + " blocks were rendered").appendTo(this.$status);
+                }
+                if (data.nb_macros > 0) {
+                    $('<div />').text(data.nb_macros + " macros were rendered").appendTo(this.$status);
+                }
+                if (typeof data.callgraph !== 'undefined') {
+                    this.$callgraph.html(data.callgraph);
                 }
             });
         }

--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -19,7 +19,13 @@
                 $('<span />').addClass(csscls('name')).text(tpl.name).appendTo(li);
 
                 if (typeof tpl.xdebug_link !== 'undefined') {
-                    $('<a href="' + tpl.xdebug_link + '"></a>').addClass(csscls('editor-link')).appendTo(li);
+                    if (tpl.xdebug_link.ajax) {
+                        $('<a title="' + tpl.xdebug_link.url + '"></a>').on('click', function () {
+                            $.ajax(tpl.xdebug_link.url);
+                        }).addClass(csscls('editor-link')).appendTo(li);
+                    } else {
+                        $('<a href="' + tpl.xdebug_link.url + '"></a>').addClass(csscls('editor-link')).appendTo(li);
+                    }
                 }
                 if (tpl.render_time_str) {
                     $('<span title="Render time" />').addClass(csscls('render-time')).text(tpl.render_time_str).appendTo(li);


### PR DESCRIPTION
This adds a Debugbar\Bridge\TwigProfileCollector utilizing the class Twig_Extension_Profiler (provided by twig) as an alternative to (replacement for) Debugbar\Bridge\Twig\TwigCollector.

The first commit contains the base feature, the second the documentation and the third contains a derived Twig_Extension to also measure the rendering on the TImeline-Tab.

This should fix #192 and probably also #243 and #324 