### PR TITLE
AssetCollection typehint in JavascriptRenderer

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -767,7 +767,7 @@ class JavascriptRenderer
      *    elements); it must be embedded within the <head> element
      *
      * @param string $type Optionally return only 'css', 'js', or 'inline_head' collection
-     * @return array or \Assetic\Asset\AssetCollection
+     * @return \Assetic\Asset\AssetCollection|\Assetic\Asset\AssetCollection[]
      */
     public function getAsseticCollection($type = null)
     {


### PR DESCRIPTION
fix the type hint for getAsseticCollection() to keep phpStorm / psalm etc happy