### PR TITLE
allow symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.0",
         "psr/log": "^1.0",
-        "symfony/var-dumper": "^2.6|^3.0"
+        "symfony/var-dumper": "^2.6|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0"


### PR DESCRIPTION
Ease constraint on `symfony/var-dumper` to allow Symfony 4.

If this gets merged in, could it also be tagged as a patch? Thank you!