### PR TITLE
Check that xdebug_link isn't null

### DIFF
--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -18,7 +18,7 @@
             this.$list = new  PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, tpl) {
                 $('<span />').addClass(csscls('name')).text(tpl.name).appendTo(li);
 
-                if (typeof tpl.xdebug_link !== 'undefined') {
+                if (typeof tpl.xdebug_link !== 'undefined' && tpl.xdebug_link !== null) {
                     if (tpl.xdebug_link.ajax) {
                         $('<a title="' + tpl.xdebug_link.url + '"></a>').on('click', function () {
                             $.ajax(tpl.xdebug_link.url);


### PR DESCRIPTION
Sometimes `tpl.xdebug_link` is defined, but has a null value, which causes a check for `.ajax` to throw an error.