### PR TITLE
Traced statement interpolation fixes

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -107,8 +107,14 @@ class TracedStatement
         }
 
         $sql = $this->sql;
+
+        $cleanBackRefCharMap = array('%'=>'%%', '$'=>'$%', '\\'=>'\\%');
+
         foreach ($this->parameters as $k => $v) {
-            $v = "$quoteLeft$v$quoteRight";
+
+            $backRefSafeV = strtr($v, $cleanBackRefCharMap);
+
+            $v = "$quoteLeft$backRefSafeV$quoteRight";
             if (!is_numeric($k)) {
                 $sql = preg_replace("/{$k}\b/", $v, $sql, 1);
             } else {
@@ -116,6 +122,9 @@ class TracedStatement
                 $sql = substr($sql, 0, $p) . $v. substr($sql, $p + 1);
             }
         }
+
+        $sql = strtr($sql, array_flip($cleanBackRefCharMap));
+
         return $sql;
     }
 

--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -115,12 +115,16 @@ class TracedStatement
             $backRefSafeV = strtr($v, $cleanBackRefCharMap);
 
             $v = "$quoteLeft$backRefSafeV$quoteRight";
-            if (!is_numeric($k)) {
-                $sql = preg_replace("/{$k}\b/", $v, $sql, 1);
+
+            if (is_numeric($k)) {
+                $marker = "\?";
             } else {
-                $p = strpos($sql, '?');
-                $sql = substr($sql, 0, $p) . $v. substr($sql, $p + 1);
+                $marker = (preg_match("/^:/", $k)) ? $k : ":" . $k;
             }
+
+            $matchRule = "/({$marker}(?!\w))(?=(?:[^$quotationChar]|[$quotationChar][^$quotationChar]*[$quotationChar])*$)/";
+
+            $sql = preg_replace($matchRule, $v, $sql, 1);
         }
 
         $sql = strtr($sql, array_flip($cleanBackRefCharMap));

--- a/tests/DebugBar/Tests/TracedStatementTest.php
+++ b/tests/DebugBar/Tests/TracedStatementTest.php
@@ -37,4 +37,22 @@ class TracedStatementTest extends DebugBarTestCase
         $result = $traced->getSqlWithParams();
         $this->assertEquals($expected, $result);
     }
+
+    public function testReplacementParamsContainingBackReferenceSyntaxGeneratesCorrectString()
+    {
+        $hashedPassword = '$2y$10$S3Y/kSsx8Z5BPtdd9.k3LOkbQ0egtsUHBT9EGQ.spxsmaEWbrxBW2';
+        $sql = "UPDATE user SET password = :password";
+
+        $params = array(
+            ':password' => $hashedPassword,
+        );
+
+        $traced = new TracedStatement($sql, $params);
+
+        $result = $traced->getSqlWithParams();
+
+        $expected = "UPDATE user SET password = <$hashedPassword>";
+
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/DebugBar/Tests/TracedStatementTest.php
+++ b/tests/DebugBar/Tests/TracedStatementTest.php
@@ -55,4 +55,67 @@ class TracedStatementTest extends DebugBarTestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testReplacementParamsContainingPotentialAdditionalQuestionMarkPlaceholderGeneratesCorrectString()
+    {
+        $hasQuestionMark = "Asking a question?";
+        $string          = "Asking for a friend";
+
+        $sql = "INSERT INTO questions SET question = ?, detail = ?";
+
+        $params = array($hasQuestionMark, $string);
+
+        $traced = new TracedStatement($sql, $params);
+
+        $result = $traced->getSqlWithParams();
+
+        $expected = "INSERT INTO questions SET question = <$hasQuestionMark>, detail = <$string>";
+
+        $this->assertEquals($expected, $result);
+
+        $result = $traced->getSqlWithParams("'");
+
+        $expected = "INSERT INTO questions SET question = '$hasQuestionMark', detail = '$string'";
+
+        $this->assertEquals($expected, $result);
+
+        $result = $traced->getSqlWithParams('"');
+
+        $expected = "INSERT INTO questions SET question = \"$hasQuestionMark\", detail = \"$string\"";
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testReplacementParamsContainingPotentialAdditionalNamedPlaceholderGeneratesCorrectString()
+    {
+        $hasQuestionMark = "Asking a question with a :string inside";
+        $string          = "Asking for a friend";
+
+        $sql = "INSERT INTO questions SET question = :question, detail = :string";
+
+        $params = array(
+            ':question' => $hasQuestionMark,
+            ':string'   => $string,
+        );
+
+        $traced = new TracedStatement($sql, $params);
+
+        $result = $traced->getSqlWithParams();
+
+        $expected = "INSERT INTO questions SET question = <$hasQuestionMark>, detail = <$string>";
+
+        $this->assertEquals($expected, $result);
+
+        $result = $traced->getSqlWithParams("'");
+
+        $expected = "INSERT INTO questions SET question = '$hasQuestionMark', detail = '$string'";
+
+        $this->assertEquals($expected, $result);
+
+        $result = $traced->getSqlWithParams('"');
+
+        $expected = "INSERT INTO questions SET question = \"$hasQuestionMark\", detail = \"$string\"";
+
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
I've maintained a [project](https://github.com/noahheck/E_PDOStatement) that performs similar behavior to what occurs in the `TracedStatement` (generating a string from the parameterized query with the bound arguments put in place into it), so I've seen some of the things to beware of when offering this functionality. Here's a synopsis of the issues and how I work around them:

#### Back reference syntax in the bound parameter value

If a value to be replaced back into the string contains a substring that looks like a regex back reference (e.g. `$1`), the `preg_replace` function looks to facilitate that:

i.e. password_hash function may produce something like this:

```
$2y$10$Xs/oqD0cVCb7hM1suoAD/Oqf4tlm5suTb8IsczDTnttiWUtHsb5ay
```

but the interpolated query value ends up like this:

```
y$Xs/oqD0cVCb7hM1suoAD/Oqf4tlm5suTb8IsczDTnttiWUtHsb5ay
```

```
$2y$10$Xs/oqD0cVCb7hM1suoAD/Oqf4tlm5suTb8IsczDTnttiWUtHsb5ay
  y   $Xs/oqD0cVCb7hM1suoAD/Oqf4tlm5suTb8IsczDTnttiWUtHsb5ay
```
I work around this by appending a `%` to any `$` `%` or `\` (the back reference characters) present in the bound argument value, then change them all back again afterward.

#### Placeholder substring presence in replaced value

If a replaced value within the query string contains the placeholder character for a future replacement, the replacement may be incorrectly performed against the value within that replacement:

```php
$question = "What's up?";
$person = "Rasmus";

$sql = "INSERT INTO questions SET question = ?, asker = ?";
```

Performing the translation as it was would have resulted in this:

```sql
INSERT INTO questions SET question = <What's up<Rasmus>>, asker = ?
```
I work around this by ensuring the replacement doesn't occur within a set of the `$quotationChar`.

#### Optional leading colon in parameter binding

Named placeholders are required to have a leading colon, but the colon is optional when calling `bindParam`:

```php
$sql = "INSERT INTO questions SET question = :question, asker = :asker";
$stmt = $pdo->prepare($sql);

// Both instructions below will execute correctly
$stmt->bindParam("question", $question);
$stmt->bindParam(":asker", $asker);
```
I work around this by checking for the presence of a leading colon on the bound parameter and adding it if it's not present.

I added tests for these scenarios.