### PR TITLE
 Bug fix repead params sql 

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -123,8 +123,9 @@ class TracedStatement
             }
 
             $matchRule = "/({$marker}(?!\w))(?=(?:[^$quotationChar]|[$quotationChar][^$quotationChar]*[$quotationChar])*$)/";
-
-            $sql = preg_replace($matchRule, $v, $sql, 1);
+            for ($i = 0; $i <= mb_substr_count($sql, $k); $i++) {
+                $sql = preg_replace($matchRule, $v, $sql, 1);
+            }
         }
 
         $sql = strtr($sql, array_flip($cleanBackRefCharMap));

--- a/tests/DebugBar/Tests/TracedStatementTest.php
+++ b/tests/DebugBar/Tests/TracedStatementTest.php
@@ -63,7 +63,7 @@ class TracedStatementTest extends DebugBarTestCase
 
         $sql = "INSERT INTO questions SET question = ?, detail = ?";
 
-        $params = [$hasQuestionMark, $string];
+        $params = array($hasQuestionMark, $string);
 
         $traced = new TracedStatement($sql, $params);
 

--- a/tests/DebugBar/Tests/TracedStatementTest.php
+++ b/tests/DebugBar/Tests/TracedStatementTest.php
@@ -25,10 +25,10 @@ class TracedStatementTest extends DebugBarTestCase
                 from geral.exame_part ep
                 where ep.id_exame = :id_exame and 
                       ep.id_exame_situacao = :id_exame_situacao';
-        $params = [
+        $params = array(
             ':id_exame'          => 1,
             ':id_exame_situacao' => 2
-        ];
+        );
         $traced = new TracedStatement($sql, $params);
         $expected = 'select *
                 from geral.exame_part ep
@@ -43,9 +43,9 @@ class TracedStatementTest extends DebugBarTestCase
         $hashedPassword = '$2y$10$S3Y/kSsx8Z5BPtdd9.k3LOkbQ0egtsUHBT9EGQ.spxsmaEWbrxBW2';
         $sql = "UPDATE user SET password = :password";
 
-        $params = [
+        $params = array(
             ':password' => $hashedPassword,
-        ];
+        );
 
         $traced = new TracedStatement($sql, $params);
 
@@ -93,10 +93,10 @@ class TracedStatementTest extends DebugBarTestCase
 
         $sql = "INSERT INTO questions SET question = :question, detail = :string";
 
-        $params = [
+        $params = array(
             ':question' => $hasQuestionMark,
             ':string'   => $string,
-        ];
+        );
 
         $traced = new TracedStatement($sql, $params);
 
@@ -137,9 +137,9 @@ class TracedStatementTest extends DebugBarTestCase
                   on c.id_person = p.id_person
                 where c.status = :status and 
                       p.status <> :status';
-        $params = [
+        $params = array(
             ':status' => 1
-        ];
+        );
         $traced = new TracedStatement($sql, $params);
         $expected = 'select *
                 from geral.person p


### PR DESCRIPTION

 Before fix it : 
select *  from geral.person p
             left join geral.contract c
                    on c.id_person = p.id_person
             where c.status = <1> and
                        p.status <> :status;
 

`
public function testRepeadParamsQuery()
{

     $sql = 'select *
                from geral.person p
                left join geral.contract c
                  on c.id_person = p.id_person
                where c.status = :status and 
                      p.status <> :status';
        $params = array(
            ':status' => 1
        );

        $traced = new TracedStatement($sql, $params);
        $expected = 'select *
                from geral.person p
                left join geral.contract c
                  on c.id_person = p.id_person
                where c.status = <1> and 
                      p.status <> <1>';
        $result = $traced->getSqlWithParams();
        $this->assertEquals($expected, $result);
 }`
    