### PR TITLE
truncate the filename part in the dataset title if its too long

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -379,6 +379,13 @@ if (typeof(PhpDebugBar) == 'undefined') {
             } else {
                 filename = uri.substr(uri.lastIndexOf('/') + 1);
             }
+            
+            // truncate the filename in the label, if it's too long
+            var maxLength = 150;
+            if (filename.length > maxLength) {
+                filename = filename.substr(0, maxLength) + '...';
+            }
+
             var label = "#" + nb + " " + filename + suffix + ' (' + data['__meta']['datetime'].split(' ')[1] + ')';
             return label;
         }


### PR DESCRIPTION
fixes #386
i had the same issue, very annoying indeed. firefox doesn't crash. i tried to disable the hardware acceleration in chrome, seemed promising, but did't solve that.

i suppose this PR is not the quality for a permanent fix (sorry for that), but i hope someone more skilled can improve the PR.