### PR TITLE
Stop TracedStatement throwing warnings for objects

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -74,7 +74,11 @@ class TracedStatement
     public function checkParameters($params)
     {
         foreach ($params as &$param) {
-            if (!mb_check_encoding($param, 'UTF-8')) {
+            if (is_object($param) && method_exists($param, '__toString')) {
+                $param = (string)$param;
+            }
+
+            if (is_object($param) || !mb_check_encoding($param, 'UTF-8')) {
                 $param = '[BINARY DATA]';
             }
         }

--- a/tests/DebugBar/Tests/TestMessage.php
+++ b/tests/DebugBar/Tests/TestMessage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DebugBar\Tests;
+
+class TestMessage
+{
+    /**
+     * @var string
+     */
+    private $message;
+
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    public function __toString()
+    {
+        return $this->message;
+    }
+}

--- a/tests/DebugBar/Tests/TracedStatementTest.php
+++ b/tests/DebugBar/Tests/TracedStatementTest.php
@@ -150,4 +150,36 @@ class TracedStatementTest extends DebugBarTestCase
         $result = $traced->getSqlWithParams();
         $this->assertEquals($expected, $result);
     }
+
+    public function testObjectWithoutToStringDoNotTriggerWarnings()
+    {
+        $sql = 'select *
+                from geral.person p
+                where c.created_at = :date';
+        $params = array(
+            ':date' => \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '1970-01-01 00:00:00'),
+        );
+        $traced = new TracedStatement($sql, $params);
+        $expected = 'select *
+                from geral.person p
+                where c.created_at = <[BINARY DATA]>';
+        $result = $traced->getSqlWithParams();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testObjectWithToStringMethodCastToString()
+    {
+        $sql = 'select *
+                from messages m
+                where m.message = :message';
+        $params = array(
+            ':message' => new TestMessage('Test Message'),
+        );
+        $traced = new TracedStatement($sql, $params);
+        $expected = 'select *
+                from messages m
+                where m.message = <Test Message>';
+        $result = $traced->getSqlWithParams();
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
The current behaviour of `TracedStatement::checkParameters()` will cause warnings to be raised when objects are passed in as a parameter. This should not always be the case.

This PR adds support for both objects with and without `__toString()` methods.

If an object has a `__toString()` method, then we will call that and use that as our parameter.

If it does not, then we will short circuit the encoding check and just make it show up as `[BINARY DATA]`.

Another option, which is preferred would be to add another possible value such as `[OBJECT classname]` which would differentiate it from standard binary data.