### PR TITLE
Add body message to mail

### DIFF
--- a/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php
+++ b/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php
@@ -38,7 +38,8 @@ class SwiftMailCollector extends DataCollector implements Renderable, AssetProvi
             $mails[] = array(
                 'to' => $this->formatTo($msg->getTo()),
                 'subject' => $msg->getSubject(),
-                'headers' => $msg->getHeaders()->toString()
+                'headers' => $msg->getHeaders()->toString(),
+                'body' => $msg->getBody()
             );
         }
         return array(

--- a/src/DebugBar/Resources/widgets/mails/widget.js
+++ b/src/DebugBar/Resources/widgets/mails/widget.js
@@ -27,6 +27,9 @@
                         }
                     });
                 }
+                if (mail.body) {
+                    $('<div />').html(mail.body).appendTo(li);
+                }
             }});
             this.$list.$el.appendTo(this.$el);
 


### PR DESCRIPTION
I'd like to have the body but also to be able to interpret HTML. To have a better look at what the user will received.
Here's an example
![image](https://user-images.githubusercontent.com/8361115/48400685-57592180-e727-11e8-92fb-2729e19a6179.png)

Let me know if you think this should be done in an other way.

Cheers,

Jonathan