### PR TITLE
Adapt swiftmailer object instantiating since new version (6)

### DIFF
--- a/demo/bridge/swiftmailer/.gitignore
+++ b/demo/bridge/swiftmailer/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/demo/bridge/swiftmailer/index.php
+++ b/demo/bridge/swiftmailer/index.php
@@ -8,12 +8,12 @@ $debugbarRenderer->setBaseUrl('../../../src/DebugBar/Resources');
 use DebugBar\Bridge\SwiftMailer\SwiftLogCollector;
 use DebugBar\Bridge\SwiftMailer\SwiftMailCollector;
 
-$mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
+$mailer = new Swift_Mailer(new Swift_NullTransport);
 
 $debugbar['messages']->aggregate(new SwiftLogCollector($mailer));
 $debugbar->addCollector(new SwiftMailCollector($mailer));
 
-$message = Swift_Message::newInstance('Wonderful Subject')
+$message = (new Swift_Message('Wonderful Subject'))
   ->setFrom(array('john@doe.com' => 'John Doe'))
   ->setTo(array('receiver@domain.org', 'other@domain.org' => 'A name'))
   ->setBody('Here is the message itself');


### PR DESCRIPTION
Since SwiftMailer v.6, they removed the `newInstance` method. 
I allowed myself to add the `gitignore` since it was a bit annoying to reset all those files created to make a commit