### PR TITLE
Improving some PHPDoc types and array notation for readability

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TraceablePDO.php
+++ b/src/DebugBar/DataCollector/PDO/TraceablePDO.php
@@ -14,13 +14,13 @@ class TraceablePDO extends PDO
     /** @var PDO */
     protected $pdo;
 
-    /** @var array */
-    protected $executedStatements = array();
+    /** @var TracedStatement[] */
+    protected $executedStatements = [];
 
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
-        $this->pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('DebugBar\DataCollector\PDO\TraceablePDOStatement', array($this)));
+        $this->pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, [TraceablePDOStatement::class, [$this]]);
     }
 
 	/**
@@ -130,7 +130,7 @@ class TraceablePDO extends PDO
    * PDO::prepare returns a PDOStatement object. If the database server cannot successfully prepare
    * the statement, PDO::prepare returns FALSE or emits PDOException (depending on error handling).
 	 */
-    public function prepare($statement, $driver_options = array())
+    public function prepare($statement, $driver_options = [])
     {
         return $this->pdo->prepare($statement, $driver_options);
     }
@@ -202,7 +202,7 @@ class TraceablePDO extends PDO
 
         $ex = null;
         try {
-            $result = call_user_func_array(array($this->pdo, $method), $args);
+            $result = $this->__call($method, $args);
         } catch (PDOException $e) {
             $ex = $e;
         }
@@ -264,7 +264,7 @@ class TraceablePDO extends PDO
     /**
      * Returns the list of executed statements as TracedStatement objects
      *
-     * @return array
+     * @return TracedStatement[]
      */
     public function getExecutedStatements()
     {
@@ -274,7 +274,7 @@ class TraceablePDO extends PDO
     /**
      * Returns the list of failed statements
      *
-     * @return array
+     * @return TracedStatement[]
      */
     public function getFailedExecutedStatements()
     {
@@ -306,6 +306,6 @@ class TraceablePDO extends PDO
      */
     public function __call($name, $args)
     {
-        return call_user_func_array(array($this->pdo, $name), $args);
+        return call_user_func_array([$this->pdo, $name], $args);
     }
 }

--- a/src/DebugBar/DataCollector/PDO/TraceablePDOStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TraceablePDOStatement.php
@@ -15,7 +15,7 @@ class TraceablePDOStatement extends PDOStatement
     protected $pdo;
 
     /** @var array */
-    protected $boundParameters = array();
+    protected $boundParameters = [];
 
     /**
      * TraceablePDOStatement constructor.
@@ -42,8 +42,8 @@ class TraceablePDOStatement extends PDOStatement
     public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null)
     {
         $this->boundParameters[$column] = $param;
-        $args = array_merge(array($column, &$param), array_slice(func_get_args(), 2));
-        return call_user_func_array(array("parent", 'bindColumn'), $args);
+        $args = array_merge([$column, &$param], array_slice(func_get_args(), 2));
+        return call_user_func_array(['parent', 'bindColumn'], $args);
     }
 
     /**
@@ -64,8 +64,8 @@ class TraceablePDOStatement extends PDOStatement
     public function bindParam($parameter, &$variable, $data_type = PDO::PARAM_STR, $length = null, $driver_options = null)
     {
         $this->boundParameters[$parameter] = $variable;
-        $args = array_merge(array($parameter, &$variable), array_slice(func_get_args(), 2));
-        return call_user_func_array(array("parent", 'bindParam'), $args);
+        $args = array_merge([$parameter, &$variable], array_slice(func_get_args(), 2));
+        return call_user_func_array(['parent', 'bindParam'], $args);
     }
 
     /**
@@ -83,7 +83,7 @@ class TraceablePDOStatement extends PDOStatement
     public function bindValue($parameter, $value, $data_type = PDO::PARAM_STR)
     {
         $this->boundParameters[$parameter] = $value;
-        return call_user_func_array(array("parent", 'bindValue'), func_get_args());
+        return call_user_func_array(['parent', 'bindValue'], func_get_args());
     }
 
     /**
@@ -93,6 +93,7 @@ class TraceablePDOStatement extends PDOStatement
      * @param  array $input_parameters [optional] An array of values with as many elements as there
      * are bound parameters in the SQL statement being executed. All values are treated as
      * PDO::PARAM_STR.
+     * @throws PDOException
      * @return bool TRUE on success or FALSE on failure.
      */
     public function execute($input_parameters = null)

--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -32,7 +32,7 @@ class TracedStatement
      * @param array $params
      * @param string $preparedId
      */
-    public function __construct($sql, array $params = array(), $preparedId = null)
+    public function __construct($sql, array $params = [], $preparedId = null)
     {
         $this->sql = $sql;
         $this->parameters = $this->checkParameters($params);
@@ -52,8 +52,8 @@ class TracedStatement
     /**
      * @param \Exception|null $exception
      * @param int $rowCount
-     * @param null $endTime
-     * @param null $endMemory
+     * @param float $endTime
+     * @param int $endMemory
      */
     public function end(\Exception $exception = null, $rowCount = 0, $endTime = null, $endMemory = null)
     {
@@ -68,8 +68,8 @@ class TracedStatement
     /**
      * Check parameters for illegal (non UTF-8) strings, like Binary data.
      *
-     * @param $params
-     * @return mixed
+     * @param array $params
+     * @return array
      */
     public function checkParameters($params)
     {
@@ -82,7 +82,7 @@ class TracedStatement
     }
 
     /**
-     * Returns the SQL string used for the query
+     * Returns the SQL string used for the query, without filled parameters
      *
      * @return string
      */
@@ -108,7 +108,7 @@ class TracedStatement
 
         $sql = $this->sql;
 
-        $cleanBackRefCharMap = array('%'=>'%%', '$'=>'$%', '\\'=>'\\%');
+        $cleanBackRefCharMap = ['%' => '%%', '$' => '$%', '\\' => '\\%'];
 
         foreach ($this->parameters as $k => $v) {
 
@@ -150,7 +150,7 @@ class TracedStatement
      */
     public function getParameters()
     {
-        $params = array();
+        $params = [];
         foreach ($this->parameters as $name => $param) {
             $params[$name] = htmlentities($param, ENT_QUOTES, 'UTF-8', false);
         }
@@ -178,7 +178,7 @@ class TracedStatement
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getStartTime()
     {
@@ -186,7 +186,7 @@ class TracedStatement
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getEndTime()
     {
@@ -194,9 +194,9 @@ class TracedStatement
     }
 
     /**
-     * Returns the duration in seconds of the execution
+     * Returns the duration in seconds + microseconds of the execution
      *
-     * @return int
+     * @return float
      */
     public function getDuration()
     {
@@ -204,7 +204,7 @@ class TracedStatement
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getStartMemory()
     {
@@ -212,7 +212,7 @@ class TracedStatement
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getEndMemory()
     {
@@ -252,7 +252,7 @@ class TracedStatement
     /**
      * Returns the exception's code
      *
-     * @return string
+     * @return int|string
      */
     public function getErrorCode()
     {


### PR DESCRIPTION
I found some parts of TraceablePDO-related code a bit confusing (using it for extra tasks on my project), so I'm clearing it up here :)

I would also like to ask if it's needed to keep all those repeated methods inside TraceablePDO; if `__call()` already forwards all calls, why pollute the new class file with meaningless forwarding methods?