### PR TITLE
Makes the PDO wrapper transparent

### DIFF
--- a/docs/base_collectors.md
+++ b/docs/base_collectors.md
@@ -64,15 +64,11 @@ Display exceptions
 
 ## PDO
 
-Logs SQL queries. You need to wrap your `PDO` object into a `DebugBar\DataCollector\PDO\TraceablePDO` object.
+Logs SQL queries.
 
-    $pdo = new DebugBar\DataCollector\PDO\TraceablePDO(new PDO('sqlite::memory:'));
     $debugbar->addCollector(new DebugBar\DataCollector\PDO\PDOCollector($pdo));
 
 You can even log queries from multiple `PDO` connections:
-
-    $pdoRead  = new DebugBar\DataCollector\PDO\TraceablePDO(new PDO('sqlite::memory:'));
-    $pdoWrite = new DebugBar\DataCollector\PDO\TraceablePDO(new PDO('sqlite::memory:'));
 
     $pdoCollector = new DebugBar\DataCollector\PDO\PDOCollector();
     $pdoCollector->addConnection($pdoRead, 'read-db');

--- a/src/DebugBar/DataCollector/PDO/PDOCollector.php
+++ b/src/DebugBar/DataCollector/PDO/PDOCollector.php
@@ -24,7 +24,7 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
      * @param TraceablePDO $pdo
      * @param TimeDataCollector $timeCollector
      */
-    public function __construct(TraceablePDO $pdo = null, TimeDataCollector $timeCollector = null)
+    public function __construct(\PDO $pdo = null, TimeDataCollector $timeCollector = null)
     {
         $this->timeCollector = $timeCollector;
         if ($pdo !== null) {
@@ -65,10 +65,13 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
      * @param TraceablePDO $pdo
      * @param string $name Optional connection name
      */
-    public function addConnection(TraceablePDO $pdo, $name = null)
+    public function addConnection(\PDO $pdo, $name = null)
     {
         if ($name === null) {
             $name = spl_object_hash($pdo);
+        }
+        if ($pdo instanceof \PDO) {
+            $pdo = new TraceablePDO($pdo);
         }
         $this->connections[$name] = $pdo;
     }

--- a/src/DebugBar/DataCollector/PDO/PDOCollector.php
+++ b/src/DebugBar/DataCollector/PDO/PDOCollector.php
@@ -21,7 +21,7 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
     protected $sqlQuotationChar = '<>';
 
     /**
-     * @param TraceablePDO $pdo
+     * @param \PDO $pdo
      * @param TimeDataCollector $timeCollector
      */
     public function __construct(\PDO $pdo = null, TimeDataCollector $timeCollector = null)
@@ -70,7 +70,7 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
         if ($name === null) {
             $name = spl_object_hash($pdo);
         }
-        if ($pdo instanceof \PDO) {
+        if (!($pdo instanceof TraceablePDO)) {
             $pdo = new TraceablePDO($pdo);
         }
         $this->connections[$name] = $pdo;


### PR DESCRIPTION
It's easy to auto-wrap the PDO object inside the collector. As the wrapped object is only useful to the collector, it seems this responsibility should be internal.