### PR TITLE
JavaScriptRenderer: support deleting stacked data

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -971,9 +971,10 @@ class JavascriptRenderer
      *
      * @param boolean $initialize Whether or not to render the debug bar initialization code
      * @param boolean $renderStackedData Whether or not to render the stacked data
+     * @param boolean $deleteStackedData Whether or not to delete the stacked data after rendering
      * @return string
      */
-    public function render($initialize = true, $renderStackedData = true)
+    public function render($initialize = true, $renderStackedData = true, $deleteStackedData = false)
     {
         $js = '';
 
@@ -982,7 +983,7 @@ class JavascriptRenderer
         }
 
         if ($renderStackedData && $this->debugBar->hasStackedData()) {
-            foreach ($this->debugBar->getStackedData() as $id => $data) {
+            foreach ($this->debugBar->getStackedData($deleteStackedData) as $id => $data) {
                 $js .= $this->getAddDatasetCode($id, $data, '(stacked)');
             }
         }


### PR DESCRIPTION
This pull request adds `$deleteStackedData`, a parameter similar to `$renderStackedData` which automatically deletes stacked data alongside rendering it.

This change allows the use case where stacked data should only be rendered once.

A workaround is to delete the data manually after rendering:

```php
$html = $bar->getRenderer()->render();
if ($bar->hasStackedData()) {
  $bar->getStackedData(true);
}
echo $html;
```