### PR TITLE
FIX PHP 5.4 compat for using function return value in write context

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -175,8 +175,9 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function getXdebugLinkTemplate()
     {
-        if (empty($this->xdebugLinkTemplate) && !empty(ini_get('xdebug.file_link_format'))) {
-            $this->xdebugLinkTemplate = ini_get('xdebug.file_link_format');
+        $fileLinkFormat = ini_get('xdebug.file_link_format');
+        if (empty($this->xdebugLinkTemplate) && !empty($fileLinkFormat)) {
+            $this->xdebugLinkTemplate = $fileLinkFormat;
         }
 
         return $this->xdebugLinkTemplate;

--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -91,13 +91,13 @@ abstract class DataCollector implements DataCollectorInterface
             $file = strtr($file, $this->xdebugReplacements);
         }
 
-        $url = strtr($this->getXdebugLinkTemplate(), ['%f' => $file, '%l' => $line]);
+        $url = strtr($this->getXdebugLinkTemplate(), array('%f' => $file, '%l' => $line));
         if ($url) {
-            return ['url' => $url, 'ajax' => $this->getXdebugShouldUseAjax()];
+            return array('url' => $url, 'ajax' => $this->getXdebugShouldUseAjax());
         }
     }
-  
-    /**  
+
+    /**
      * Sets the default variable dumper used by all collectors subclassing this class
      *
      * @param DebugBarVarDumper $varDumper

--- a/src/DebugBar/Storage/FileStorage.php
+++ b/src/DebugBar/Storage/FileStorage.php
@@ -52,7 +52,8 @@ class FileStorage implements StorageInterface
         //Loop through all .json files and remember the modified time and id.
         $files = array();
         foreach (new \DirectoryIterator($this->dirname) as $file) {
-            if ($file->getExtension() == 'json') {
+            $file_extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+            if ($file_extension == 'json') {
                 $files[] = array(
                     'time' => $file->getMTime(),
                     'id' => $file->getBasename('.json')


### PR DESCRIPTION
This restores compatibility with older PHP versions. [v1.15.0 still allows PHP 5.3 or greater](https://github.com/maximebf/php-debugbar/blob/v1.15.0/composer.json#L20).

It'd be great if you could release this in a 1.15.x patch, I realise it'll be slightly annoying since other commits exist in master already which bump these requirements.

You can see the error here: https://travis-ci.org/lekoala/silverstripe-debugbar/jobs/508134678#L528