### PR TITLE
Force open handle font color

### DIFF
--- a/src/DebugBar/Resources/openhandler.css
+++ b/src/DebugBar/Resources/openhandler.css
@@ -19,6 +19,7 @@ div.phpdebugbar-openhandler {
     width: 70%;
     height: 70%;
     background: #fff;
+    color: #000;
     border: 2px solid #888;
     overflow: auto;
     z-index: 20001;


### PR DESCRIPTION
When the underlying website uses a white font color (dark theme...) the content is not visible.