### PR TITLE
docs: Replace deprecated ExceptionsCollector->addException() by addThrowable()

### DIFF
--- a/docs/base_collectors.md
+++ b/docs/base_collectors.md
@@ -59,7 +59,7 @@ Display exceptions
     try {
         throw new Exception('foobar');
     } catch (Exception $e) {
-        $debugbar['exceptions']->addException($e);
+        $debugbar['exceptions']->addThrowable($e);
     }
 
 ## PDO


### PR DESCRIPTION
ExceptionsCollector->addException() is deprecated since #281.