### PR TITLE
Deprecate TwigCollector and friends

### DIFF
--- a/demo/bridge/twig/index.php
+++ b/demo/bridge/twig/index.php
@@ -6,9 +6,11 @@ include __DIR__ . '/../../bootstrap.php';
 $debugbarRenderer->setBaseUrl('../../../src/DebugBar/Resources');
 
 $loader = new Twig_Loader_Filesystem('.');
-$twig = new DebugBar\Bridge\Twig\TraceableTwigEnvironment(new Twig_Environment($loader), $debugbar['time']);
+$twig = new Twig_Environment($loader);
+$profile = new Twig_Profiler_Profile();
+$twig->addExtension(new DebugBar\Bridge\Twig\TimeableTwigExtensionProfiler($profile, $debugbar['time']));
 
-$debugbar->addCollector(new DebugBar\Bridge\Twig\TwigCollector($twig));
+$debugbar->addCollector(new DebugBar\Bridge\TwigProfileCollector($profile));
 
 render_demo_page(function() use ($twig) {
     echo $twig->render('hello.html', array('name' => 'peter pan'));

--- a/docs/bridge_collectors.md
+++ b/docs/bridge_collectors.md
@@ -90,22 +90,9 @@ Display log messages and sent mail using `DebugBar\Bridge\SwiftMailer\SwiftLogCo
 
 http://twig.sensiolabs.org/
 
-Collects info about rendered templates using `DebugBar\Bridge\Twig\TwigCollector`.
-You need to wrap your `Twig_Environment` object into a `DebugBar\Bridge\Twig\TraceableTwigEnvironment` object.
-
-    $loader = new Twig_Loader_Filesystem('.');
-    $env = new DebugBar\Bridge\Twig\TraceableTwigEnvironment(new Twig_Environment($loader));
-    $debugbar->addCollector(new DebugBar\Bridge\Twig\TwigCollector($env));
-
-You can provide a `DebugBar\DataCollector\TimeDataCollector` as the second argument of
-`TraceableTwigEnvironment` so render operation can be measured.
-
-## Twig (Profiler)
-
-An alternative to `DebugBar\Bridge\Twig\TwigCollector` for newer versions of twig.
 This collector uses the class `Twig_Extension_Profiler` to collect info about rendered
 templates, blocks and macros.
-You need to inject the root-`Twig_Profiler_Profile` into the collector:
+You need to inject the root `Twig_Profiler_Profile` into the collector:
 
     $loader = new Twig_Loader_Filesystem('.');
     $env = new Twig_Environment($loader);
@@ -119,6 +106,6 @@ You can optionally use `DebugBar\Bridge\Twig\TimeableTwigExtensionProfiler` in p
     $loader = new Twig_Loader_Filesystem('.');
     $env = new Twig_Environment($loader);
     $profile = new Twig_Profiler_Profile();
-    $env->addExtension(new TimeableTwigExtensionProfiler($profile, $debugbar['time']));
+    $env->addExtension(new DebugBar\Bridge\Twig\TimeableTwigExtensionProfiler($profile, $debugbar['time']));
     $debugbar->addCollector(new DebugBar\Bridge\TwigProfileCollector($profile));
 

--- a/src/DebugBar/Bridge/Twig/TraceableTwigEnvironment.php
+++ b/src/DebugBar/Bridge/Twig/TraceableTwigEnvironment.php
@@ -24,6 +24,8 @@ use Twig_TokenStream;
 
 /**
  * Wrapped a Twig Environment to provide profiling features
+ * 
+ * @deprecated
  */
 class TraceableTwigEnvironment extends Twig_Environment
 {

--- a/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
+++ b/src/DebugBar/Bridge/Twig/TraceableTwigTemplate.php
@@ -15,6 +15,8 @@ use Twig_TemplateInterface;
 
 /**
  * Wraps a Twig_Template to add profiling features
+ * 
+ * @deprecated
  */
 class TraceableTwigTemplate extends Twig_Template implements Twig_TemplateInterface
 {

--- a/src/DebugBar/Bridge/Twig/TwigCollector.php
+++ b/src/DebugBar/Bridge/Twig/TwigCollector.php
@@ -26,6 +26,8 @@ use DebugBar\DataCollector\Renderable;
  * $env = new TraceableTwigEnvironment(new Twig_Environment($loader));
  * $debugbar->addCollector(new TwigCollector($env));
  * </code>
+ * 
+ * @deprecated use DebugBar\Bridge\TwigProfileCollector instead
  */
 class TwigCollector extends DataCollector implements Renderable, AssetProvider
 {


### PR DESCRIPTION
The reasoning behind this merge is to get rid of the `TwigCollector`, which seems to work only for `twig/twig <2`.

Since there is an alternative `TwigProfileCollector` which seems to work throughout v1 and v2 of Twig, I have updated the demo to use that instead.

And also cleaned the bridge documentation to reflect the now absent `TwigCollector`.

This fixes #423. WDYT @barryvdh?