### PR TITLE
Add void return type hint for MonologCollector::write()

### DIFF
--- a/src/DebugBar/Bridge/MonologCollector.php
+++ b/src/DebugBar/Bridge/MonologCollector.php
@@ -59,7 +59,7 @@ class MonologCollector extends AbstractProcessingHandler implements DataCollecto
     /**
      * @param array $record
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $this->records[] = array(
             'message' => $record['formatted'],


### PR DESCRIPTION
This would fix an issue who uses `MonologCollector` with `Monolog` v2.

There is an issue when you try to use `Bridge/MonologCollector` because the abstract method signature has changed in `Monolog` v2. The diff: https://github.com/Seldaek/monolog/commit/06143b03e5c1598bfa6c6df65432010da0ecc28b#diff-d1d031ebe96084844fb53eb650bc404eR50

However, this change is a bit tricky. Because `Monolog` in v2 has increased PHP dependency to `^7.2`, also added those void return type hints. So this change could break things for people who uses `MonologCollector` with PHP version lower than 7.1.