### PR TITLE
Symfony 5 support added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.1",
         "psr/log": "^1.0",
-        "symfony/var-dumper": "^2.6|^3|^4"
+        "symfony/var-dumper": "^2.6|^3|^4|^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5"


### PR DESCRIPTION
Added Symfony 5 support. No changes in https://github.com/symfony/symfony/blob/5.0/UPGRADE-5.0.md regarding VarDumper so it should be good to go

#SymfonyHackday

