### PR TITLE
Fixing JavaScript error (Internet Explorer)

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1160,7 +1160,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             var self = this;
             var proxied = window.fetch;
 
-            if (proxied === undefined && proxied.polyfill !== undefined) {
+            if (proxied !== undefined && proxied.polyfill !== undefined) {
                 return;
             }
 


### PR DESCRIPTION
Fixing a JS error preventing the debug bar to be displayed on Internet explorer.