### PR TITLE
Add return value to measure() function.

### DIFF
--- a/src/DebugBar/DataCollector/TimeDataCollector.php
+++ b/src/DebugBar/DataCollector/TimeDataCollector.php
@@ -134,6 +134,7 @@ class TimeDataCollector extends DataCollector implements Renderable
      * @param string $label
      * @param \Closure $closure
      * @param string|null $collector
+     * @return mixed
      */
     public function measure($label, \Closure $closure, $collector = null)
     {
@@ -142,6 +143,7 @@ class TimeDataCollector extends DataCollector implements Renderable
         $result = $closure();
         $params = is_array($result) ? $result : array();
         $this->stopMeasure($name, $params);
+        return $result;
     }
 
     /**

--- a/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
@@ -45,4 +45,16 @@ class TimeDataCollectorTest extends DebugBarTestCase
         $this->assertTrue($data['duration'] > 0);
         $this->assertCount(2, $data['measures']);
     }
+
+    public function testMeasure()
+    {
+        $returned = $this->c->measure('bar', function() {
+            return 'returnedValue';
+        });
+        $m = $this->c->getMeasures();
+        $this->assertCount(1, $m);
+        $this->assertEquals('bar', $m[0]['label']);
+        $this->assertTrue($m[0]['start'] < $m[0]['end']);
+        $this->assertSame('returnedValue', $returned);
+    }
 }


### PR DESCRIPTION
The goal to this PR is to be able to have the return value from the measure function.

Currently to obtain the same result we have to add a reference in the called closure as:
```
        $debugbar->measure(
            $label,
            function () use (&$output) {
                $output = 'AnyReturnValue';
            }
        );
        var_dump($output);
```

So now we can just do: 

```
        $output = $debugbar->measure(
            $label,
            function () {
                return 'AnyReturnValue';
            }
        );
        var_dump($output);
```