### PR TITLE
Remove broken fetch catch

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1169,8 +1169,6 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
                 promise.then(function (response) {
                     self.handle(response);
-                }, function (e) {
-                    self.handle(response);
                 });
 
                 return promise;


### PR DESCRIPTION
I think doing nothing here is fine; `response` isn't available in the catch.