### PR TITLE
Trigger resize on new dataset

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -944,6 +944,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             var self = this;
             this.openHandler.load(id, function(data) {
                 self.addDataSet(data, id, suffix, show);
+                self.resize();
                 callback && callback(data);
             });
         },


### PR DESCRIPTION
When a new dataset is loaded, the layout can change. Trigger the resize to make it fit directly. Fixes #445