### PR TITLE
Improve assertion and ignore cached PHPUnit file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 composer.lock
 /vendor
+/demo/bridge/*/vendor
 /src/DebugBar/Resources/vendor
+.phpunit.result.cache

--- a/tests/DebugBar/Tests/DataCollector/AggregatedCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/AggregatedCollectorTest.php
@@ -17,7 +17,7 @@ class AggregatedCollectorTest extends DebugBarTestCase
         $this->c->addCollector($c = new MockCollector());
         $this->assertContains($c, $this->c->getCollectors());
         $this->assertEquals($c, $this->c['mock']);
-        $this->assertTrue(isset($this->c['mock']));
+        $this->assertArrayHasKey('mock', $this->c);
     }
 
     public function testCollect()

--- a/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
@@ -33,7 +33,7 @@ class TimeDataCollectorTest extends DebugBarTestCase
         $this->assertEquals('bar', $m[0]['label']);
         $this->assertEquals('baz', $m[0]['collector']);
         $this->assertEquals(array('bar' => 'baz'), $m[0]['params']);
-        $this->assertTrue($m[0]['start'] < $m[0]['end']);
+        $this->assertLessThan($m[0]['end'], $m[0]['start']);
     }
 
     public function testCollect()
@@ -41,8 +41,8 @@ class TimeDataCollectorTest extends DebugBarTestCase
         $this->c->addMeasure('foo', 0, 10);
         $this->c->addMeasure('bar', 10, 20);
         $data = $this->c->collect();
-        $this->assertTrue($data['end'] > $this->s);
-        $this->assertTrue($data['duration'] > 0);
+        $this->assertGreaterThan($this->s, $data['end']);
+        $this->assertGreaterThan(0, $data['duration']);
         $this->assertCount(2, $data['measures']);
     }
 
@@ -54,7 +54,7 @@ class TimeDataCollectorTest extends DebugBarTestCase
         $m = $this->c->getMeasures();
         $this->assertCount(1, $m);
         $this->assertEquals('bar', $m[0]['label']);
-        $this->assertTrue($m[0]['start'] < $m[0]['end']);
+        $this->assertLessThan($m[0]['end'], $m[0]['start']);
         $this->assertSame('returnedValue', $returned);
     }
 }

--- a/tests/DebugBar/Tests/DebugBarTest.php
+++ b/tests/DebugBar/Tests/DebugBarTest.php
@@ -42,8 +42,8 @@ class DebugBarTest extends DebugBarTestCase
     {
         $this->debugbar->addCollector($c = new MockCollector());
         $this->assertEquals($c, $this->debugbar['mock']);
-        $this->assertTrue(isset($this->debugbar['mock']));
-        $this->assertFalse(isset($this->debugbar['foo']));
+        $this->assertArrayHasKey('mock', $this->debugbar);
+        $this->assertArrayNotHasKey('foo', $this->debugbar);
     }
 
     public function testStorage()
@@ -96,7 +96,7 @@ class DebugBarTest extends DebugBarTestCase
         $data = $this->debugbar->getStackedData();
         $this->assertArrayNotHasKey($ns, $http->session);
         $this->assertArrayHasKey($id, $data);
-        $this->assertEquals(1, count($data));
+        $this->assertCount(1, $data);
         $this->assertArrayHasKey('mock', $data[$id]);
         $this->assertEquals($c->collect(), $data[$id]['mock']);
     }

--- a/tests/DebugBar/Tests/DebugBarTestCase.php
+++ b/tests/DebugBar/Tests/DebugBarTestCase.php
@@ -17,13 +17,13 @@ abstract class DebugBarTestCase extends TestCase
     public function assertJsonIsArray($json)
     {
         $data = json_decode($json);
-        $this->assertTrue(is_array($data));
+        $this->assertIsArray($data);
     }
 
     public function assertJsonIsObject($json)
     {
         $data = json_decode($json);
-        $this->assertTrue(is_object($data));
+        $this->assertIsObject($data);
     }
 
     public function assertJsonArrayNotEmpty($json)


### PR DESCRIPTION
# Changed log

- Improve some PHPUnit assertions.
- Let the `.phpunit.result.cache` file be on `.gitignore` file and this is generated by `PHPUnit 9.x.` version.