### PR TITLE
Wrong variable name in docblock

### DIFF
--- a/src/DebugBar/DataFormatter/DataFormatterInterface.php
+++ b/src/DebugBar/DataFormatter/DataFormatterInterface.php
@@ -18,7 +18,7 @@ interface DataFormatterInterface
     /**
      * Transforms a PHP variable to a string representation
      *
-     * @param mixed $var
+     * @param mixed $data
      * @return string
      */
     function formatVar($data);


### PR DESCRIPTION
I was getting strange warnings like this in my logs:
```
2021-02-06T17:55:18+01:00 [info] User Deprecated: The "DebugBar\DataFormatter\DataFormatter::formatVar()" method will require a new "mixed $var" argument in the next major version of its interface "DebugBar\DataFormatter\DataFormatterInterface", not defining it is deprecated.
```
Turns out it was caused by this docblock having the wrong variable name.