### PR TITLE
Add support for PSR-3 message placeholders

### DIFF
--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -185,7 +185,29 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
      */
     public function log($level, $message, array $context = array())
     {
-        $this->addMessage($message, $level);
+        $this->addMessage($this->interpolate($message, $context), $level);
+    }
+
+    /**
+     * Interpolates context values into the message placeholders.
+     *
+     * @param $message
+     * @param array $context
+     * @return string
+     */
+    function interpolate($message, array $context = array())
+    {
+        // build a replacement array with braces around the context keys
+        $replace = array();
+        foreach ($context as $key => $val) {
+            // check that the value can be cast to string
+            if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString'))) {
+                $replace['{' . $key . '}'] = $val;
+            }
+        }
+
+        // interpolate replacement values into the message and return
+        return strtr($message, $replace);
     }
 
     /**


### PR DESCRIPTION
This is an optional part of the PSR-3 spec: https://www.php-fig.org/psr/psr-3/#12-message

It allows injecting values in log messages like this:
```php
$logger->error('User {username} does not exist.', ['username' => $username]);
```