### PR TITLE
Fix of error HtmlDumper::setDumpHeader() must be of the type string

### DIFF
--- a/src/DebugBar/DataFormatter/DebugBarVarDumper.php
+++ b/src/DebugBar/DataFormatter/DebugBarVarDumper.php
@@ -285,7 +285,7 @@ class DebugBarVarDumper implements AssetProvider
      */
     public function getAssets() {
         $dumper = $this->getDumper();
-        $dumper->setDumpHeader(null); // this will cause the default dump header to regenerate
+        $dumper->setDumpHeader(''); // this will cause the default dump header to regenerate
         return array(
             'inline_head' => array(
                 'html_var_dumper' => $dumper->getDumpHeaderByDebugBar(),


### PR DESCRIPTION
Fix to work with the new method signature of Symfony's `HtmlDumper::setDumpHeader` which now requires string as parameter and does now accept null 

TypeError
Argument 1 passed to Symfony\Component\VarDumper\Dumper\HtmlDumper::setDumpHeader() must be of the type string, null given, called in C:\xampp\htdocs\test\vendor\maximebf\debugbar\src\DebugBar\DataFormatter\DebugBarVarDumper.php on line 288



As temporary fix you can use older version of `var-dumper`, the version that works is `"symfony/var-dumper": "v5.2.11"` , new versions does not work