### PR TITLE
Fix vardumper #474

### DIFF
--- a/src/DebugBar/DataFormatter/DebugBarVarDumper.php
+++ b/src/DebugBar/DataFormatter/DebugBarVarDumper.php
@@ -285,7 +285,7 @@ class DebugBarVarDumper implements AssetProvider
      */
     public function getAssets() {
         $dumper = $this->getDumper();
-        $dumper->setDumpHeader(null); // this will cause the default dump header to regenerate
+        $dumper->resetDumpHeader(); // this will cause the default dump header to regenerate
         return array(
             'inline_head' => array(
                 'html_var_dumper' => $dumper->getDumpHeaderByDebugBar(),

--- a/src/DebugBar/DataFormatter/VarDumper/DebugBarHtmlDumper.php
+++ b/src/DebugBar/DataFormatter/VarDumper/DebugBarHtmlDumper.php
@@ -10,6 +10,14 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper;
  */
 class DebugBarHtmlDumper extends HtmlDumper
 {
+    /**
+     * Resets an HTML header.
+     */
+    public function resetDumpHeader()
+    {
+        $this->dumpHeader = null;
+    }
+
     public function getDumpHeaderByDebugBar() {
         // getDumpHeader is protected:
         return str_replace('pre.sf-dump', '.phpdebugbar pre.sf-dump', $this->getDumpHeader());


### PR DESCRIPTION
Reset the dumpHeader by adding a new method, because we cannot set `null` anymore, since typehints have been added (see https://github.com/maximebf/php-debugbar/issues/474)