### PR TITLE
Check log messages before interpolate

### DIFF
--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -185,7 +185,11 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
      */
     public function log($level, $message, array $context = array())
     {
-        $this->addMessage($this->interpolate($message, $context), $level);
+        // For string messages, interpolate the context following PSR-3
+        if (is_string($message)) {
+            $message = $this->interpolate($message, $context);
+        }
+        $this->addMessage($message, $level);
     }
 
     /**


### PR DESCRIPTION
Fixes #476, builds upon #465

The PSR-3 spec describes logging strings, but this worked before in Debugbar. 
This is only affected for the PSR-3 methods, not addMessage.