### PR TITLE
Add #[ReturnTypeWillChange] attribute to suppress deprecation warning…

### DIFF
--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -481,6 +481,7 @@ class DebugBar implements ArrayAccess
         return $this->getCollector($key);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->hasCollector($key);


### PR DESCRIPTION
…s and fatal error

Error occurs on php 7.4 >=