### PR TITLE
updated psr/log acceptable mayor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.1|^8",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "symfony/var-dumper": "^2.6|^3|^4|^5"
     },
     "require-dev": {


### PR DESCRIPTION
psr/log2 is essentially psr/log1 with new php8 syntax but as long as this pkg is locked into psr/log1 this leads to an incompatible situations like the one described here: https://github.com/barryvdh/laravel-debugbar/issues/1244

Also if some pkgs require psr/log2, the psr/log1 lock will make this unnecessarily incompatible.