### PR TITLE
php 8.1 deprecations

### DIFF
--- a/src/DebugBar/DataFormatter/DataFormatter.php
+++ b/src/DebugBar/DataFormatter/DataFormatter.php
@@ -76,7 +76,7 @@ class DataFormatter implements DataFormatterInterface
         $sign = $size < 0 ? '-' : '';
         $size = abs($size);
 
-        $base = (int) log($size) / log(1024);
+        $base = log($size) / log(1024);
         $suffixes = array('B', 'KB', 'MB', 'GB', 'TB');
         return $sign . round(pow(1024, $base - floor($base)), $precision) . $suffixes[floor($base)];
     }

--- a/src/DebugBar/DataFormatter/DataFormatter.php
+++ b/src/DebugBar/DataFormatter/DataFormatter.php
@@ -76,7 +76,7 @@ class DataFormatter implements DataFormatterInterface
         $sign = $size < 0 ? '-' : '';
         $size = abs($size);
 
-        $base = log($size) / log(1024);
+        $base = (int) log($size) / log(1024);
         $suffixes = array('B', 'KB', 'MB', 'GB', 'TB');
         return $sign . round(pow(1024, $base - floor($base)), $precision) . $suffixes[floor($base)];
     }

--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -789,6 +789,8 @@ class JavascriptRenderer
             return $uris;
         }
 
+        $uri = $uri ?? '';
+
         if (substr($uri, 0, 1) === '/' || preg_match('/^([a-zA-Z]+:\/\/|[a-zA-Z]:\/|[a-zA-Z]:\\\)/', $uri)) {
             return $uri;
         }
@@ -805,7 +807,7 @@ class JavascriptRenderer
     protected function filterAssetArray($array, $type = '')
     {
         $types = array('css', 'js', 'inline_css', 'inline_js', 'inline_head');
-        $typeIndex = array_search(strtolower($type), $types);
+        $typeIndex = array_search(strtolower($type ?? ''), $types);
         return $typeIndex !== false ? $array[$typeIndex] : $array;
     }
 


### PR DESCRIPTION
Discovered in Joomla  running under php 8.1

- `Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated `
- `Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated `
- `Deprecated: Implicit conversion from float -INF to int loses precision`