### PR TITLE
PHP 8.1 fix in DataFormatter.php for "Implicit conversion from float-INF to int loses precision"

### DIFF
--- a/src/DebugBar/DataFormatter/DataFormatter.php
+++ b/src/DebugBar/DataFormatter/DataFormatter.php
@@ -78,6 +78,6 @@ class DataFormatter implements DataFormatterInterface
 
         $base = log($size) / log(1024);
         $suffixes = array('B', 'KB', 'MB', 'GB', 'TB');
-        return $sign . round(pow(1024, $base - floor($base)), $precision) . $suffixes[floor($base)];
+        return $sign . round(pow(1024, $base - floor($base)), $precision) . $suffixes[(int) floor($base)];
     }
 }


### PR DESCRIPTION
This fixes a PHP 8.1 bug "Deprecated: Implicit conversion from float -INF to int loses precision in vendor/maximebf/debugbar/src/DebugBar/DataFormatter/DataFormatter.php