### PR TITLE
Always provide htmlentities with a string, for PHP8.1

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -152,7 +152,7 @@ class TracedStatement
     {
         $params = [];
         foreach ($this->parameters as $name => $param) {
-            $params[$name] = htmlentities($param, ENT_QUOTES, 'UTF-8', false);
+            $params[$name] = htmlentities($param?:"", ENT_QUOTES, 'UTF-8', false);
         }
         return $params;
     }


### PR DESCRIPTION
In PHP8.1, htmlentities doesn't accept null as valid first argument; cast any equivalent-to-false into string before passing it to htmlentities.