### PR TITLE
Fix random instances of SQL queries having params repeated

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -123,7 +123,7 @@ class TracedStatement
             }
 
             $matchRule = "/({$marker}(?!\w))(?=(?:[^$quotationChar]|[$quotationChar][^$quotationChar]*[$quotationChar])*$)/";
-            for ($i = 0; $i <= mb_substr_count($sql, $k); $i++) {
+            for ($i = 0; $i <= mb_substr_count($sql, $matchRule); $i++) {
                 $sql = preg_replace($matchRule, $v, $sql, 1);
             }
         }

--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -123,7 +123,11 @@ class TracedStatement
             }
 
             $matchRule = "/({$marker}(?!\w))(?=(?:[^$quotationChar]|[$quotationChar][^$quotationChar]*[$quotationChar])*$)/";
-            for ($i = 0; $i <= mb_substr_count($sql, $matchRule); $i++) {
+            $count = mb_substr_count($sql, $k);
+            if ($count < 1) {
+                $count = mb_substr_count($sql, $matchRule);
+            }
+            for ($i = 0; $i <= $count; $i++) {
                 $sql = preg_replace($matchRule, $v, $sql, 1);
             }
         }

--- a/tests/DebugBar/Tests/TracedStatementTest.php
+++ b/tests/DebugBar/Tests/TracedStatementTest.php
@@ -150,4 +150,25 @@ class TracedStatementTest extends DebugBarTestCase
         $result = $traced->getSqlWithParams();
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Check that query parameters are being replaced only once
+     * @bugFix Before fix it: select * from
+     *                          `my_table` where `my_field` between
+     *                           <2018-01-01> and <2018-01-01>
+     * @return void
+     */
+    public function testParametersAreNotRepeated()
+    {
+        $query = 'select * from `my_table` where `my_field` between ? and ?';
+        $bindings = [
+            '2018-01-01',
+            '2020-09-01',
+        ];
+
+        $this->assertEquals(
+            'select * from `my_table` where `my_field` between <2018-01-01> and <2020-09-01>',
+            (new TracedStatement($query, $bindings))->getSqlWithParams()
+        );
+    }
 }


### PR DESCRIPTION
In my application, I noticed that on seemingly random occurrences, parameters would be repeated when replacing them in the SQL query string: (notice that they display fine in the table under the query, but the first one is inserted in all 3 locations)
<img width="792" alt="Screen Shot 2022-05-29 at 17 26 38" src="https://user-images.githubusercontent.com/26070412/170895455-440b8f7f-059a-4d7d-a750-1a28c5d5db96.png">

This PR fixes this issue.

Looking at open issues here, this seems to be the same issue as https://github.com/maximebf/php-debugbar/issues/457, but this problem arises for me without using `BETWEEN` statements... 🤔 

I have added a test, and all tests are passing.