### PR TITLE
Fix monolog 3 compat

### DIFF
--- a/src/DebugBar/Bridge/MonologCollector.php
+++ b/src/DebugBar/Bridge/MonologCollector.php
@@ -57,9 +57,9 @@ class MonologCollector extends AbstractProcessingHandler implements DataCollecto
     }
 
     /**
-     * @param array $record
+     * @param array|\Monolog\LogRecord $record
      */
-    protected function write(array $record): void
+    protected function write($record): void
     {
         $this->records[] = array(
             'message' => $record['formatted'],


### PR DESCRIPTION
In monolog 3, write method now accepts a LogRecord object (https://github.com/Seldaek/monolog/commit/22c8b19358e916c52f1d2170d44e172152de7c25) instead of an array. The PR makes the debugbar collector compatible with that signature.