### PR TITLE
Fix PHP 8.2 deprecation

### DIFF
--- a/src/DebugBar/DataFormatter/DataFormatter.php
+++ b/src/DebugBar/DataFormatter/DataFormatter.php
@@ -15,6 +15,10 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 
 class DataFormatter implements DataFormatterInterface
 {
+    public $cloner;
+
+    public $dumper;
+
     /**
      * DataFormatter constructor.
      */


### PR DESCRIPTION
Dynamic properties are deprecated in PHP 8.2 and will be removed in PHP 9.0. This PR fixes a deprecation error on the `DebugBar/DataFormatter/DataFormatter` class where two dynamic name properties are created in the constructor, by explicitly marking them as (public) class properties.

Reference: https://wiki.php.net/rfc/deprecate_dynamic_properties