### PR TITLE
fix: Fix FileStorage::find function

### DIFF
--- a/src/DebugBar/Storage/FileStorage.php
+++ b/src/DebugBar/Storage/FileStorage.php
@@ -62,7 +62,7 @@ class FileStorage implements StorageInterface
 
         //Sort the files, newest first
         usort($files, function ($a, $b) {
-                return $a['time'] < $b['time'];
+                return $a['time'] - $b['time'];
             });
 
         //Load the metadata and filter the results.


### PR DESCRIPTION
Fix FileStorage::find function usort callback function to return int instead of bool, because after PHP8 bool return value for the callback function is not supported.