### PR TITLE
Fix event listener when URL is object

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1207,7 +1207,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 var xhr = this;
                 this.addEventListener("readystatechange", function() {
                     var skipUrl = self.debugbar.openHandler ? self.debugbar.openHandler.get('url') : null;
-                    if (xhr.readyState == 4 && url.indexOf(skipUrl) !== 0) {
+                    var href = (typeof url === 'string') ? url : url.href;
+                    
+                    if (xhr.readyState == 4 && href.indexOf(skipUrl) !== 0) {
                         self.handle(xhr);
                     }
                 }, false);


### PR DESCRIPTION
Sometimes, when we are using TS in project, the event listener receives a URL object instead string:
https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts#L17144

When this happens, the following error appears:
![image](https://user-images.githubusercontent.com/11338999/214643043-5ad6cffc-3b6d-40a2-a30d-29f69ed2d739.png)

The code changed in this PR prevents this error.