### PR TITLE
Add initial values to traceable PDO array_reduce()

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TraceablePDO.php
+++ b/src/DebugBar/DataCollector/PDO/TraceablePDO.php
@@ -248,7 +248,7 @@ class TraceablePDO extends PDO
      */
     public function getAccumulatedStatementsDuration() : float
     {
-        return array_reduce($this->executedStatements, function ($v, $s) { return $v + $s->getDuration(); });
+        return array_reduce($this->executedStatements, function ($v, $s) { return $v + $s->getDuration(); }, 0.0);
     }
 
     /**
@@ -258,7 +258,7 @@ class TraceablePDO extends PDO
      */
     public function getMemoryUsage() : int
     {
-        return array_reduce($this->executedStatements, function ($v, $s) { return $v + $s->getMemoryUsage(); });
+        return array_reduce($this->executedStatements, function ($v, $s) { return $v + $s->getMemoryUsage(); }, 0);
     }
 
     /**
@@ -268,7 +268,7 @@ class TraceablePDO extends PDO
      */
     public function getPeakMemoryUsage() : int
     {
-        return array_reduce($this->executedStatements, function ($v, $s) { $m = $s->getEndMemory(); return $m > $v ? $m : $v; });
+        return array_reduce($this->executedStatements, function ($v, $s) { $m = $s->getEndMemory(); return $m > $v ? $m : $v; }, 0);
     }
 
     /**


### PR DESCRIPTION
If the PDOTraceableDataCollector is enabled and no database calls happen to be made in a request, PHP 8.1 emits a fatal error, e.g.,

```
<b>Fatal error</b>: Uncaught TypeError:
DebugBar\DataCollector\PDO\TraceablePDO::getAccumulatedStatementsDuration():
Return value must be of type float, null returned in
vendor/maximebf/debugbar/src/DebugBar/DataCollector/PDO/TraceablePDO.php:251
```

The same error occurs in getMemoryUsage() and getPeakMemoryUsage().

Adding an initial value of 0 to `array_reduce()` corrects the problem.

Fixes #522.