### PR TITLE
Fix PHP 8.2 deprecations

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TraceablePDOStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TraceablePDOStatement.php
@@ -84,7 +84,7 @@ class TraceablePDOStatement extends PDOStatement
     public function bindValue($parameter, $value, $data_type = PDO::PARAM_STR) : bool
     {
         $this->boundParameters[$parameter] = $value;
-        return call_user_func_array(['parent', 'bindValue'], func_get_args());
+        return parent::bindValue(...func_get_args());
     }
 
     /**

--- a/tests/DebugBar/Tests/DataCollector/AggregatedCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/AggregatedCollectorTest.php
@@ -7,6 +7,8 @@ use DebugBar\DataCollector\AggregatedCollector;
 
 class AggregatedCollectorTest extends DebugBarTestCase
 {
+    private $c;
+
     public function setUp(): void
     {
         $this->c = new AggregatedCollector('test');

--- a/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
@@ -7,6 +7,9 @@ use DebugBar\DataCollector\TimeDataCollector;
 
 class TimeDataCollectorTest extends DebugBarTestCase
 {
+    private $s;
+    private $c;
+
     public function setUp(): void
     {
         $this->s = microtime(true);

--- a/tests/DebugBar/Tests/DebugBarTestCase.php
+++ b/tests/DebugBar/Tests/DebugBarTestCase.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 abstract class DebugBarTestCase extends TestCase
 {
+    protected $debugbar;
+
     public function setUp(): void
     {
         $this->debugbar = new DebugBar();

--- a/tests/DebugBar/Tests/OpenHandlerTest.php
+++ b/tests/DebugBar/Tests/OpenHandlerTest.php
@@ -9,6 +9,8 @@ use DebugBar\Tests\Storage\MockStorage;
 
 class OpenHandlerTest extends DebugBarTestCase
 {
+    private $openHandler;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/DebugBar/Tests/Storage/FileStorageTest.php
+++ b/tests/DebugBar/Tests/Storage/FileStorageTest.php
@@ -8,6 +8,8 @@ use DebugBar\Storage\FileStorage;
 class FileStorageTest extends DebugBarTestCase
 {
     private $dirname;
+    private $s;
+    private $data;
 
     public function setUp(): void
     {


### PR DESCRIPTION
- Use of "parent" in callables is deprecated
- Creation of dynamic properties is deprecated since php 8.2 (used in some test)