### PR TITLE
Fix error when using RedisCluster with phpredis

### DIFF
--- a/src/DebugBar/Storage/RedisStorage.php
+++ b/src/DebugBar/Storage/RedisStorage.php
@@ -57,7 +57,7 @@ class RedisStorage implements StorageInterface
     {
         $results = [];
         $cursor = "0";
-        $isPhpRedis = get_class($this->redis) === 'Redis';
+        $isPhpRedis = get_class($this->redis) === 'Redis' || get_class($this->redis) === 'RedisCluster';
 
         do {
             if ($isPhpRedis) {


### PR DESCRIPTION
When using Redis Cluster with phpredis, the class is not 'Redis', but 'RedisCluster' and the code only checks for the first one. This change fixes the `Undefined array key 0` that appears in this situation.