### PR TITLE
docs: Fix class name missing full import

### DIFF
--- a/docs/base_collectors.md
+++ b/docs/base_collectors.md
@@ -115,7 +115,7 @@ Aggregates multiple collectors. Do not provide any widgets, you have to add your
 
     $debugbar->addCollector(new DebugBar\DataCollector\AggregatedCollector('all_messages', 'messages', 'time'));
     $debugbar['all_messages']->addCollector($debugbar['messages']);
-    $debugbar['all_messages']->addCollector(new MessagesCollector('mails'));
+    $debugbar['all_messages']->addCollector(new DebugBar\DataCollector\MessagesCollector('mails'));
     $debugbar['all_messages']['mails']->addMessage('sending mail');
 
     $renderer = $debugbar->getJavascriptRenderer();


### PR DESCRIPTION
Also: why is the website not up to date with the docs ?
There is `;` instead of `,` in http://phpdebugbar.com/docs/base-collectors.html#others
Line 125 of this file