### PR TITLE
[bug] Fix multiple replacement on the same path

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -87,8 +87,15 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function getXdebugLink($file, $line = 1)
     {
-        if (count($this->xdebugReplacements)) {
-            $file = strtr($file, $this->xdebugReplacements);
+        if (file_exists($file)) {
+            $file = realpath($file);
+        }
+
+        foreach ($this->xdebugReplacements as $path => $replacement) {
+            if (strpos($file, $path) === 0) {
+            	$file = $replacement . substr($file, strlen($path));
+            	break;
+            }
         }
 
         $url = strtr($this->getXdebugLinkTemplate(), ['%f' => $file, '%l' => $line]);


### PR DESCRIPTION
If you have small, common paths on the server, it will replace all matches, not just the prefix

[Running Demo](https://onlinephp.io?s=lVNda8IwFH1eof_hTgptQe32qqtDZOxle9nTxjZGTaMtxiTkYzrE_74k1basCjMPJffr3HtPT-7uecF9L0ngjWkBiOUYCizwte8hkkkJM0YIRoqJne-BOVwwZWycQ7DN8VwvXzAnGcJrTJWEFN6rNHvCZMp5COkEwtnogzCUkbDfDm82m9Phz7HvHdrpOSkRLDRFqmQUlli9urZPJV1FwaIkuA8BKSk2vW_jqmjXNCkXECGmqYoCVZRyMOkOHcftAnscrMGTSihRNzlbP26q99W1dgistKAV4CFtf241ijePF263YAJnqIDzy0EmIeCZKizPgWginaUtU2ZhzmTd2NbFkKYp3HTSr44ktUFhCFLPZUOauRJMowqpTZSDmJvpV3-c-0vJdHz63nEcJ7rk-cd-jb6SGaNKWA0LG2isodF96GQWVEJP7Q9o5B7FLmgexsOWO8GPnNU7avWfPXquaoqUzshJhNpq6o6uDtJ3Jr5yveZRNfNgcuI5OJo7iafFZXJ_AQ%2C%2C&v=7.1.0)

```php
$xdebugReplacements = [
      '/App' => 'C:\local',
      '/www' => 'C:\local',
  ];
$file = '/App/MyApp/www/Controller/AppController.php';
$class->getXdebugLink($file);
// Expected:
// "C:\local/MyApp/www/Controller/AppController.php"
// Actual:
// "C:\local/MyAppC:\local/ControllerC:\localController.php"
```

