### PR TITLE
Remove xdebug replacements on file path previews

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -75,6 +75,32 @@ abstract class DataCollector implements DataCollectorInterface
     }
 
     /**
+     * Shorten the file path by removing the xdebug path replacements
+     *
+     * @param string $file
+     * @return string
+     */
+    public function normalizeFilePath($file)
+    {
+        if (empty($file)) {
+            return '';
+        }
+
+        if (file_exists($file)) {
+            $file = realpath($file);
+        }
+
+        foreach (array_keys($this->xdebugReplacements) as $path) {
+            if (strpos($file, $path) === 0) {
+            	$file = substr($file, strlen($path));
+                break;
+            }
+        }
+
+        return ltrim(str_replace('\\', '/', $file), '/');
+    }
+
+    /**
      * Get an Xdebug Link to a file
      *
      * @param string $file

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -139,7 +139,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
             'type' => get_class($e),
             'message' => $e->getMessage(),
             'code' => $e->getCode(),
-            'file' => $filePath,
+            'file' => $this->normalizeFilePath($filePath),
             'line' => $e->getLine(),
             'stack_trace' => $e->getTraceAsString(),
             'stack_trace_html' => $traceHtml,


### PR DESCRIPTION
This method would allow showing only relative paths based on `xdebugReplacements`
this can be very helpful in integrations

This PR hides remote server paths on previews

Before 
![image](https://github.com/maximebf/php-debugbar/assets/4933954/e38486c5-47aa-4a21-a6e9-b64c00220d6f)
After
![image](https://github.com/maximebf/php-debugbar/assets/4933954/ca7a9b0d-c0c3-4c82-99c9-9eb086353e1b)