### PR TITLE
Support editors when php.ini not available

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -183,6 +183,39 @@ abstract class DataCollector implements DataCollectorInterface
     }
 
     /**
+     * @param string $editor
+     */
+    public function setEditorLinkTemplate($editor)
+    {
+        $editorLinkTemplates = array(
+            'sublime' => 'subl://open?url=file://%f&line=%l',
+            'textmate' => 'txmt://open?url=file://%f&line=%l',
+            'emacs' => 'emacs://open?url=file://%f&line=%l',
+            'macvim' => 'mvim://open/?url=file://%f&line=%l',
+            'phpstorm' => 'phpstorm://open?file=%f&line=%l',
+            'phpstorm-remote' => 'javascript:let r=new XMLHttpRequest;' .
+                'r.open("get","http://localhost:63342/api/file/%f:%l");r.send()',
+            'idea' => 'idea://open?file=%f&line=%l',
+            'idea-remote' => 'javascript:let r=new XMLHttpRequest;' .
+                'r.open("get","http://localhost:63342/api/file/?file=%f&line=%l");r.send()',
+            'vscode' => 'vscode://file/%f:%l',
+            'vscode-insiders' => 'vscode-insiders://file/%f:%l',
+            'vscode-remote' => 'vscode://vscode-remote/%f:%l',
+            'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/%f:%l',
+            'vscodium' => 'vscodium://file/%f:%l',
+            'nova' => 'nova://core/open/file?filename=%f&line=%l',
+            'xdebug' => 'xdebug://%f@%l',
+            'atom' => 'atom://core/open/file?filename=%f&line=%l',
+            'espresso' => 'x-espresso://open?filepath=%f&lines=%l',
+            'netbeans' => 'netbeans://open/?f=%f:%l',
+        );
+
+        if (is_string($editor) && isset($editorLinkTemplates[$editor])) {
+            $this->setXdebugLinkTemplate($editorLinkTemplates[$editor]);
+        }
+    }
+
+    /**
      * @param string $xdebugLinkTemplate
      * @param bool $shouldUseAjax
      */


### PR DESCRIPTION
**Examples:**
[spatie/ignition/IgnitionConfig.php#L152-L217](https://github.com/spatie/ignition/blob/710b745eeb77ca4c3b9847611b285aa0a3538254/src/Config/IgnitionConfig.php#L152-L217)
[filp/whoops/PrettyPageHandler.php#L114-L125](https://github.com/filp/whoops/blob/c83e88a30524f9360b11f585f71e6b17313b7187/src/Whoops/Handler/PrettyPageHandler.php#L114-L125)

List of known editors and their link formats, for easier integration