### PR TITLE
[bug] Early return when empty file string

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -87,6 +87,10 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function getXdebugLink($file, $line = 1)
     {
+        if (empty($file)) {
+            return null;
+        }
+
         if (file_exists($file)) {
             $file = realpath($file);
         }


### PR DESCRIPTION
When is empty $file, it returns an invalid url

```php
->getXdebugLink('');
//returns ['url' => 'vscode://file/:1', 'ajax' => false];
->getXdebugLink(null);
//throws exception string required null given on php 8.2
```