### PR TITLE
[bug] Stop event propagation on editor link click

### DIFF
--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -20,11 +20,14 @@
 
                 if (typeof tpl.xdebug_link !== 'undefined' && tpl.xdebug_link !== null) {
                     if (tpl.xdebug_link.ajax) {
-                        $('<a title="' + tpl.xdebug_link.url + '"></a>').on('click', function () {
+                        $('<a title="' + tpl.xdebug_link.url + '"></a>').on('click', function (event) {
+                            event.stopPropagation();
                             $.ajax(tpl.xdebug_link.url);
                         }).addClass(csscls('editor-link')).appendTo(li);
                     } else {
-                        $('<a href="' + tpl.xdebug_link.url + '"></a>').addClass(csscls('editor-link')).appendTo(li);
+                        $('<a href="' + tpl.xdebug_link.url + '"></a>').on('click', function (event) {
+                            event.stopPropagation();
+                        }).addClass(csscls('editor-link')).appendTo(li);
                     }
                 }
                 if (tpl.render_time_str) {
@@ -40,7 +43,9 @@
                     $('<span title="Type" />').addClass(csscls('type')).text(tpl.type).appendTo(li);
                 }
                 if (typeof(tpl.editorLink) != 'undefined' && tpl.editorLink) {
-                    $('<a href="'+ tpl.editorLink +'" />').addClass(csscls('editor-link')).text('file').appendTo(li);
+                    $('<a href="'+ tpl.editorLink +'" />').on('click', function (event) {
+                        event.stopPropagation();
+                    }).addClass(csscls('editor-link')).text('file').appendTo(li);
                 }
                 if (tpl.params && !$.isEmptyObject(tpl.params)) {
                     var table = $('<table><tr><th colspan="2">Params</th></tr></table>').addClass(csscls('params')).appendTo(li);


### PR DESCRIPTION
There is a problem when clicking editor links, 
when we try to open editor, the click event propagates and open/close item's description 

On `xdebug_link` and `editorLink` added:
```js
.on('click', function (event) {
    event.stopPropagation();
})
```