### PR TITLE
Add SymfonyMailCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+2023-09-08
+
+ - Add SymfonyMailCollector (#554)
+
 2021-12-21
 
  - Add support for `symfony/var-dumper^6` package

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Includes collectors for:
   - [Monolog](https://github.com/Seldaek/monolog)
   - [Propel](http://propelorm.org/)
   - [Slim](http://slimframework.com)
+  - [Symfony Mailer](https://symfony.com/doc/current/mailer.html)
   - [Swift Mailer](http://swiftmailer.org/)
   - [Twig](http://twig.symfony.com/)
 

--- a/demo/bridge/symfonymailer/composer.json
+++ b/demo/bridge/symfonymailer/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "symfony/event-dispatcher": "*",
+        "symfony/mailer": "*"
+    }
+}

--- a/demo/bridge/symfonymailer/index.php
+++ b/demo/bridge/symfonymailer/index.php
@@ -1,0 +1,48 @@
+<?php
+
+use DebugBar\Bridge\Symfony\SymfonyMailCollector;
+use DebugBar\DataCollector\MessagesCollector;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Mailer\Event\SentMessageEvent;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\Email;
+
+include __DIR__ . '/vendor/autoload.php';
+include __DIR__ . '/../../bootstrap.php';
+
+$debugbarRenderer->setBaseUrl('../../../src/DebugBar/Resources');
+
+$mailCollector = new SymfonyMailCollector();
+$debugbar->addCollector($mailCollector);
+$logger = new MessagesCollector('mails');
+$debugbar['messages']->aggregate($logger);
+
+// Add even listener for SentMessageEvent
+$dispatcher = new EventDispatcher();
+$dispatcher->addListener(SentMessageEvent::class, function (SentMessageEvent $event) use ($mailCollector): void {
+    $mailCollector->addSymfonyMessage($event->getMessage());
+});
+
+// Creates NullTransport Mailer for testing
+$mailer = new Mailer(new class ($dispatcher, $logger) extends AbstractTransport {
+    protected function doSend(\Symfony\Component\Mailer\SentMessage $message): void
+    {
+        $this->getLogger()->debug('Sending message "'.$message->getOriginalMessage()->getSubject().'"');
+    }
+    public function __toString(): string{ return 'null://'; }
+});
+
+$email = (new Email())
+    ->from('john@doe.com')
+    ->to('you@example.com')
+    //->cc('cc@example.com')
+    //->bcc('bcc@example.com')
+    //->replyTo('fabien@example.com')
+    //->priority(Email::PRIORITY_HIGH)
+    ->subject('Wonderful Subject')
+    ->text('Here is the message itself');
+
+$mailer->send($email);
+
+render_demo_page();

--- a/demo/index.php
+++ b/demo/index.php
@@ -42,6 +42,7 @@ render_demo_page(function() {
     <li><a href="bridge/propel">Propel</a></li>
     <li><a href="bridge/slim">Slim</a></li>
     <li><a href="bridge/swiftmailer">Swift mailer</a></li>
+    <li><a href="bridge/symfonymailer">Symfony mailer</a></li>
     <li><a href="bridge/twig">Twig</a></li>
 </ul>
 <?php

--- a/docs/bridge_collectors.md
+++ b/docs/bridge_collectors.md
@@ -86,6 +86,20 @@ Display log messages and sent mail using `DebugBar\Bridge\SwiftMailer\SwiftLogCo
     $debugbar['messages']->aggregate(new DebugBar\Bridge\SwiftMailer\SwiftLogCollector($mailer));
     $debugbar->addCollector(new DebugBar\Bridge\SwiftMailer\SwiftMailCollector($mailer));
 
+## Symfony Mailer
+
+https://symfony.com/doc/current/mailer.html
+
+Display log messages and sent mail using `DebugBar\Bridge\Symfony\SymfonyMailCollector`
+
+    use Symfony\Component\Mailer\Event\SentMessageEvent;
+
+    $mailCollector = new DebugBar\Bridge\Symfony\SymfonyMailCollector();
+    $debugbar->addCollector($mailCollector);
+    $eventDispatcher->addListener(SentMessageEvent::class, function (SentMessageEvent $event) use (&$mailCollector): void {
+        $mailCollector->addSymfonyMessage($event->getMessage());
+    });
+
 ## Twig
 
 http://twig.sensiolabs.org/

--- a/src/DebugBar/Bridge/Symfony/SymfonyMailCollector.php
+++ b/src/DebugBar/Bridge/Symfony/SymfonyMailCollector.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DebugBar\Bridge\Symfony;
+
+use DebugBar\DataCollector\AssetProvider;
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
+
+/**
+ * Collects data about sent mail events
+ *
+ * https://github.com/symfony/mailer
+ */
+class SymfonyMailCollector extends DataCollector implements Renderable, AssetProvider
+{
+    /** @var array */
+    private $messages = array();
+
+    /** @var bool */
+    private $showDetailed = false;
+
+    /** @param \Symfony\Component\Mailer\SentMessage $message */
+    public function addSymfonyMessage($message)
+    {
+        $this->messages[] = $message->getOriginalMessage();
+    }
+
+    public function showMessageDetail()
+    {
+        $this->showDetailed = true;
+    }
+
+    public function collect()
+    {
+        $mails = array();
+
+        foreach ($this->messages as $message) {
+            /* @var \Symfony\Component\Mime\Message $message */
+            $mails[] = array(
+                'to' => array_map(function ($address) {
+                    /* @var \Symfony\Component\Mime\Address $address */
+                    return $address->toString();
+                }, $message->getTo()),
+                'subject' => $message->getSubject(),
+                'headers' => ($this->showDetailed ? $message : $message->getHeaders())->toString(),
+            );;
+        }
+
+        return array(
+            'count' => count($mails),
+            'mails' => $mails,
+        );
+    }
+
+    public function getName()
+    {
+        return 'symfonymailer_mails';
+    }
+
+    public function getWidgets()
+    {
+        return array(
+            'emails' => array(
+                'icon' => 'inbox',
+                'widget' => 'PhpDebugBar.Widgets.MailsWidget',
+                'map' => 'symfonymailer_mails.mails',
+                'default' => '[]',
+                'title' => 'Mails'
+            ),
+            'emails:badge' => array(
+                'map' => 'symfonymailer_mails.count',
+                'default' => 'null'
+            )
+        );
+    }
+
+    public function getAssets()
+    {
+        return array(
+            'css' => 'widgets/mails/widget.css',
+            'js' => 'widgets/mails/widget.js'
+        );
+    }
+}


### PR DESCRIPTION
Since Laravel 9.x [DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php](https://github.com/maximebf/php-debugbar/blob/master/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php) is not used anymore
> _Swiftmailer is **not maintained anymore**. [Use Symfony Mailer](https://symfony.com/doc/current/mailer.html) instead._
> **source**: https://symfony.com/blog/the-end-of-swiftmailer

This PR adds SymfonyMail replacement, and reuse SwiftMailer widgets

**CC:** @barryvdh 