### PR TITLE
Add custom trace formatter helper

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -124,6 +124,16 @@ class ExceptionsCollector extends DataCollector implements Renderable
     }
 
     /**
+     * Returns Throwable data as an string
+     *
+     * @param \Throwable $e
+     * @return string
+     */
+    public function formatTraceAsString($e)
+    {
+        return $e->getTraceAsString();
+    }
+    /**
      * Returns Throwable data as an array
      *
      * @param \Throwable $e
@@ -151,7 +161,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
             'code' => $e->getCode(),
             'file' => $filePath,
             'line' => $e->getLine(),
-            'stack_trace' => $e->getTraceAsString(),
+            'stack_trace' => $this->formatTraceAsString($e),
             'stack_trace_html' => $traceHtml,
             'surrounding_lines' => $lines,
             'xdebug_link' => $this->getXdebugLink($filePath, $e->getLine())

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -116,12 +116,11 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Returns Throwable trace as an formated array
      *
-     * @param \Throwable $e
      * @return array
      */
-    public function formatTraceArray($e)
+    public function formatTrace(array $trace)
     {
-        return $e->getTrace();
+        return $trace;
     }
 
     /**
@@ -143,7 +142,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
 
         $traceHtml = null;
         if ($this->isHtmlVarDumperUsed()) {
-            $traceHtml = $this->getVarDumper()->renderVar($this->formatTraceArray($e));
+            $traceHtml = $this->getVarDumper()->renderVar($this->formatTrace($e->getTrace()));
         }
 
         return array(

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -114,6 +114,17 @@ class ExceptionsCollector extends DataCollector implements Renderable
     }
 
     /**
+     * Returns Throwable trace as an formated array
+     *
+     * @param \Throwable $e
+     * @return array
+     */
+    public function formatTraceArray($e)
+    {
+        return $e->getTrace();
+    }
+
+    /**
      * Returns Throwable data as an array
      *
      * @param \Throwable $e
@@ -132,7 +143,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
 
         $traceHtml = null;
         if ($this->isHtmlVarDumperUsed()) {
-            $traceHtml = $this->getVarDumper()->renderVar($e->getTrace());
+            $traceHtml = $this->getVarDumper()->renderVar($this->formatTraceArray($e));
         }
 
         return array(


### PR DESCRIPTION
This gives us the option to customize the exception trace.

 For example: 
- remove/normalize the path of the remote server files, or remove the vendor files from entries
- `getTraceAsString` can be changed to [php-elog/jTraceEx.php](https://github.com/tox2ik/php-elog/blob/master/src/jTraceEx.php)