### PR TITLE
(feat) memory usage  data on measure 

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -438,6 +438,19 @@ if (typeof(PhpDebugBar) == 'undefined') {
                     return (seconds).toFixed(2) +  's';
                 };
 
+                // ported from php DataFormatter
+                var formatBytes = function formatBytes(size) {
+                    if (size === 0 || size === null) {
+                        return '0B';
+                    }
+
+                    var sign = size < 0 ? '-' : '',
+                        size = Math.abs(size),
+                        base = Math.log(size) / Math.log(1024),
+                        suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
+                    return sign + (Math.round(Math.pow(1024, base - Math.floor(base)) * 100) / 100) + suffixes[Math.floor(base)];
+                }
+
                 this.$el.empty();
                 if (data.measures) {
                     var aggregate = {};
@@ -446,10 +459,11 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         var measure = data.measures[i];
 
                         if(!aggregate[measure.label])
-                            aggregate[measure.label] = { count: 0, duration: 0 };
+                            aggregate[measure.label] = { count: 0, duration: 0, memory : 0 };
 
                         aggregate[measure.label]['count'] += 1;
                         aggregate[measure.label]['duration'] += measure.duration;
+                        aggregate[measure.label]['memory'] += (measure.memory || 0);
 
                         var m = $('<div />').addClass(csscls('measure')),
                             li = $('<li />'),
@@ -460,7 +474,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
                             left: left + "%",
                             width: width + "%"
                         }));
-                        m.append($('<span />').addClass(csscls('label')).text(measure.label + " (" + measure.duration_str + ")"));
+                        m.append($('<span />').addClass(csscls('label'))
+                            .text(measure.label + " (" + measure.duration_str +(measure.memory ? '/' + measure.memory_str: '') + ")"));
 
                         if (measure.collector) {
                             $('<span />').addClass(csscls('collector')).text(measure.collector).appendTo(m);
@@ -506,7 +521,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         aggregateTable.append('<tr><td class="' + csscls('name') + '">' + aggregate.data.count + ' x ' + aggregate.label + ' (' + width + '%)</td><td class="' + csscls('value') + '">' +
                             '<div class="' + csscls('measure') +'">' +
                                 '<span class="' + csscls('value') + '" style="width:' + width + '%"></span>' +
-                                '<span class="' + csscls('label') + '">' + formatDuration(aggregate.data.duration) + '</span>' +
+                                '<span class="' + csscls('label') + '">' + formatDuration(aggregate.data.duration) + (aggregate.data.memory ? '/' + formatBytes(aggregate.data.memory) : '') + '</span>' +
                             '</div></td></tr>');
                     });
 


### PR DESCRIPTION
This is an optional config, 
allows you to measure memory usage along with time
![image](https://github.com/maximebf/php-debugbar/assets/4933954/b11f59ac-b7bd-472a-8581-334898de18fe)
This helped me optimize a method that causes a fatal memory allocated error (_was a collection filter on a foreach_ 😕)

**Usage:**
```php
$timeCollector = new TimeDataCollector();
$timeCollector->showMemoryUsage(); // without this, it works as before
```
