### PR TITLE
(fix) set memory baseline on MemoryCollector

### DIFF
--- a/src/DebugBar/DataCollector/MemoryCollector.php
+++ b/src/DebugBar/DataCollector/MemoryCollector.php
@@ -17,7 +17,16 @@ class MemoryCollector extends DataCollector implements Renderable
 {
     protected $realUsage = false;
 
+    protected $memoryRealStart = 0;
+
+    protected $memoryStart = 0;
+
     protected $peakUsage = 0;
+
+    public function __construct()
+    {
+        $this->updateMemoryBaseline();
+    }
 
     /**
      * Returns whether total allocated memory page size is used instead of actual used memory size
@@ -42,13 +51,24 @@ class MemoryCollector extends DataCollector implements Renderable
     }
 
     /**
+     * Set memory baseline for avoid problems on swoole/octane
+     *
+     * @return void
+     */
+    public function updateMemoryBaseline()
+    {
+        $this->memoryStart = memory_get_usage(false);
+        $this->memoryRealStart = memory_get_usage(true);
+    }
+
+    /**
      * Returns the peak memory usage
      *
      * @return integer
      */
     public function getPeakUsage()
     {
-        return $this->peakUsage;
+        return $this->peakUsage - ($this->realUsage ? $this->memoryRealStart : $this->memoryStart);
     }
 
     /**
@@ -66,8 +86,8 @@ class MemoryCollector extends DataCollector implements Renderable
     {
         $this->updatePeakUsage();
         return array(
-            'peak_usage' => $this->peakUsage,
-            'peak_usage_str' => $this->getDataFormatter()->formatBytes($this->peakUsage, 0)
+            'peak_usage' => $this->getPeakUsage(),
+            'peak_usage_str' => $this->getDataFormatter()->formatBytes($this->getPeakUsage(), 0)
         );
     }
 

--- a/src/DebugBar/DataCollector/MemoryCollector.php
+++ b/src/DebugBar/DataCollector/MemoryCollector.php
@@ -23,11 +23,6 @@ class MemoryCollector extends DataCollector implements Renderable
 
     protected $peakUsage = 0;
 
-    public function __construct()
-    {
-        $this->updateMemoryBaseline();
-    }
-
     /**
      * Returns whether total allocated memory page size is used instead of actual used memory size
      * by the application.  See $real_usage parameter on memory_get_peak_usage for details.
@@ -51,11 +46,11 @@ class MemoryCollector extends DataCollector implements Renderable
     }
 
     /**
-     * Set memory baseline for avoid problems on swoole/octane
+     * Reset memory baseline, to measure multiple requests in a long running process
      *
      * @return void
      */
-    public function updateMemoryBaseline()
+    public function resetMemoryBaseline()
     {
         $this->memoryStart = memory_get_usage(false);
         $this->memoryRealStart = memory_get_usage(true);


### PR DESCRIPTION
Fixes https://github.com/barryvdh/laravel-debugbar/issues/1324
Fixes https://github.com/barryvdh/laravel-debugbar/issues/1434

This pr allows only the memory peak to be shown with a baseline, this would normalize the differences in the presentation, currently the maximum peak of the process is shown, but only the memory used by the application should be shown

For example, in Windows a fresh app shows 20MB, while the same app in Linux only shows 3MB.
Added `memory_reset_peak_usage` for only check execution peaks