### PR TITLE
Fix pdo demo

### DIFF
--- a/demo/pdo.php
+++ b/demo/pdo.php
@@ -18,6 +18,6 @@ $stmt = $pdo->prepare('select * from users where name=?');
 $stmt->execute(array('foo'));
 $foo = $stmt->fetch();
 
-$pdo->exec('delete from titi');
+$pdo->exec('delete from users');
 
 render_demo_page();


### PR DESCRIPTION
There is not a `titi` table, must be `users`
```
Fatal error: Uncaught PDOException: SQLSTATE[HY000]: 
    General error: 1 no such table: titi in \src\DebugBar\DataCollector\PDO\TraceablePDO.php:319
    Stack trace: #0 [internal function]: PDO->exec('delete from tit...')   
        #1 \src\DebugBar\DataCollector\PDO\TraceablePDO.php(319):
```
https://github.com/maximebf/php-debugbar/blob/1bee67191420a999aaaeab865d28cf3ddcb60207/demo/pdo.php#L11-L21