### PR TITLE
Fix content security policy errors by upgrading jquery (fixes #529)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "maximebf/php-debugbar",
   "dependencies": {
-    "jquery": "^3.3",
+    "jquery": "^3.7",
     "font-awesome": "^4.7"
   }
 }


### PR DESCRIPTION
This fixes the content security policy errors generated by jquery not propagating the nonce to nodes it creates. (As mentionen in #529).

I have tested this for regressions.