### PR TITLE
Fix content security policy failure due to <script> tags without nonce generated by HtmlDumper

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -1046,6 +1046,10 @@ class JavascriptRenderer
 
         $nonce = $this->getNonceAttribute();
 
+	if ($nonce != '') {
+            $js = preg_replace("/<script>/", "<script nonce='{$this->cspNonce}'>", $js);
+        }
+
         if ($this->useRequireJs){
             return "<script type=\"text/javascript\"{$nonce}>\nrequire(['debugbar'], function(PhpDebugBar){ $js });\n</script>\n";
         } else {


### PR DESCRIPTION
**Short Version:**
This PR fixes csp errors caused by <script> tags without a nonce generated by HtmlDumper.

**Long version:**

`JavaScriptRenderer::render()` adds content using `JavaScriptRenderer::getAddDatasetCode()` with data from `JavaScriptRenderer::getData()`, which returns data from `JavaScriptRenderer::collect()`.

`JavaScriptRenderer::collect()` essentially does this:

```
foreach ($this->collectors as $name => $collector) {
    $this->data[$name] = $collector->collect();
}
```

For the both the request collector from maximebf/debugbar (default_request) and laravel-debugbar, the collect() function uses `$data[$key] = $this->getVarDumper()->renderVar($GLOBALS[$var]);` to render the variables.

`getVarDumper()` by default returns a `DebugBarVarDumper` instance. `DebugBarVarDumper->renderVar()` returns the result from `DebugBarVarDumper->dump()`, which, finally returns the result from `Symfony\Component\VarDumper\Dumper\HtmlDumper::dump`, which calls `parent::dump` (`AbstractDumper::dump`), which calls `dumpLine`, which embeds the data within `$this->dumpSuffix`, which contains:

```
protected $dumpSuffix = '</pre><script>Sfdump(%s)</script>';
```

...a <script> tag without a nonce!