### PR TITLE
(fix) highlighted-line emphasis on codeblock

### DIFF
--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -11,17 +11,19 @@ pre.phpdebugbar-widgets-code-block {
   pre.phpdebugbar-widgets-code-block code.phpdebugbar-widgets-numbered-code {
     padding: 5px;
   }
-    pre.phpdebugbar-widgets-code-block code span.phpdebugbar-widgets-highlighted-line {
-      background: #800000;
-      color: #fff;
-      display: inline-block;
-      min-width: 100%;
-    }
-      pre.phpdebugbar-widgets-code-block code span.phpdebugbar-widgets-highlighted-line span {
-        background: none !important;
-        color: inherit !important;
-      }
+  pre.phpdebugbar-widgets-code-block ul li.phpdebugbar-widgets-highlighted-line {
+    font-weight: bolder;
+    text-decoration: underline;
+  }
+  pre.phpdebugbar-widgets-code-block ul li.phpdebugbar-widgets-highlighted-line span {
+    position: absolute;
+    background: #800000;
+    min-width: calc(100% - 85px);
+    margin-left: 10px;
+    opacity: 0.15;
+  }
   pre.phpdebugbar-widgets-code-block ul {
+    position: static;
     float: left;
     padding: 5px;
     background: #cacaca;

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -81,29 +81,11 @@ if (typeof(PhpDebugBar) == 'undefined') {
         // incorrectly positioned - most noticeable when line numbers are shown.
         var codeElement = $('<code />').text(code + '\n').appendTo(pre);
 
-        // Add a span with a special class if we are supposed to highlight a line.  highlight.js will
-        // still correctly format code even with existing markup in it.
-        if ($.isNumeric(highlightedLine)) {
-            if ($.isNumeric(firstLineNumber)) {
-                highlightedLine = highlightedLine - firstLineNumber + 1;
-            }
-            codeElement.html(function (index, html) {
-                var currentLine = 1;
-                return html.replace(/^.*$/gm, function(line) {
-                    if (currentLine++ == highlightedLine) {
-                        return '<span class="' + csscls('highlighted-line') + '">' + line + '</span>';
-                    } else {
-                        return line;
-                    }
-                });
-            });
-        }
-
         // Format the code
         if (lang) {
-            pre.addClass("language-" + lang);
+            codeElement.addClass("language-" + lang);
         }
-        highlight(pre);
+        highlight(codeElement).removeClass('hljs');
 
         // Show line numbers in a list
         if ($.isNumeric(firstLineNumber)) {
@@ -111,7 +93,12 @@ if (typeof(PhpDebugBar) == 'undefined') {
             var $lineNumbers = $('<ul />').prependTo(pre);
             pre.children().addClass(csscls('numbered-code'));
             for (var i = firstLineNumber; i < firstLineNumber + lineCount; i++) {
-                $('<li />').text(i).appendTo($lineNumbers);
+                var li = $('<li />').text(i).appendTo($lineNumbers);
+
+                // Add a span with a special class if we are supposed to highlight a line.
+                if (highlightedLine === i) {
+                    li.addClass(csscls('highlighted-line')).append('<span>&nbsp;</span>');
+                }
             }
         }
 
@@ -565,7 +552,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
                     $('<span />').addClass(csscls('type')).text(e.type).appendTo(li);
                 }
                 if (e.surrounding_lines) {
-                    var pre = createCodeBlock(e.surrounding_lines.join(""), 'php').addClass(csscls('file')).appendTo(li);
+                    var startLine = (e.line - 3) <= 0 ? 1 : e.line - 3;
+                    var pre = createCodeBlock(e.surrounding_lines.join(""), 'php', startLine, e.line).addClass(csscls('file')).appendTo(li);
                     if (!e.stack_trace_html) {
                         // This click event makes the var-dumper hard to use.
                         li.click(function () {


### PR DESCRIPTION
- Remove security message
![image](https://github.com/maximebf/php-debugbar/assets/4933954/7d9345ac-f567-4a0a-9377-c6f8826e1411)
Before we have `'<pre><code>THIS IS CODE</code></pre>'`, so, when `highlight(pre);`, highlightjs removes `<code>` as says the warning, changing to `highlight(codeElement)` fix it, this also happen on `highlightedLine` wich adds `<span class="highlighted-line">`

- Fix highlighted line emphasis 
After #547 https://github.com/highlightjs/highlight.js/wiki/security, 
highlightjs removes all the unescaped html, this breaks highlighted line functionality([highlightjs/740#issuecomment-1298423250](https://github.com/highlightjs/highlight.js/issues/740#issuecomment-1298423250))
**BEFORE HIGHLIGHTJS UPGRADE:** This was the original functionality, the html is removed in the current version
![image](https://github.com/maximebf/php-debugbar/assets/4933954/66b2d2b2-dc0d-421a-9383-19936d222267)
**AFTER THIS FIX:** It is not the same, but it emphasizes
![image](https://github.com/maximebf/php-debugbar/assets/4933954/5822a328-348a-441f-a836-74bd7226e057)


