### PR TITLE
normalize file paths on exceptions traces

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -183,7 +183,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
             'code' => $e->getCode(),
             'file' => $this->normalizeFilePath($filePath),
             'line' => $e->getLine(),
-            'stack_trace' => $this->formatTraceAsString($e),
+            'stack_trace' => $traceHtml ? null : $this->formatTraceAsString($e),
             'stack_trace_html' => $traceHtml,
             'surrounding_lines' => $lines,
             'xdebug_link' => $this->getXdebugLink($filePath, $e->getLine())

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -120,6 +120,16 @@ class ExceptionsCollector extends DataCollector implements Renderable
      */
     public function formatTrace(array $trace)
     {
+        if (! empty($this->xdebugReplacements)) {
+            $trace = array_map(function ($track) {
+                if (isset($track['file'])) {
+                    $track['file'] = $this->normalizeFilePath($track['file']);
+                }
+
+                return $track;
+            }, $trace);
+        }
+
         return $trace;
     }
 
@@ -131,8 +141,20 @@ class ExceptionsCollector extends DataCollector implements Renderable
      */
     public function formatTraceAsString($e)
     {
+        if (! empty($this->xdebugReplacements)) {
+            return implode("\n", array_map(function ($track) {
+                $track = explode(' ', $track);
+                if (isset($track[1])) {
+                    $track[1] = $this->normalizeFilePath($track[1]);
+                }
+
+                return implode(' ', $track);
+            }, explode("\n", $e->getTraceAsString())));
+        }
+
         return $e->getTraceAsString();
     }
+
     /**
      * Returns Throwable data as an array
      *

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -169,8 +169,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
             $start = $e->getLine() - 4;
             $lines = array_slice($lines, $start < 0 ? 0 : $start, 7);
         } else {
-            $filePath = $this->normalizeFilePath($filePath);
-            $lines = array("Cannot open the file ($filePath) in which the exception occurred ");
+            $lines = array('Cannot open the file ('.$this->normalizeFilePath($filePath).') in which the exception occurred');
         }
 
         $traceHtml = null;

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -169,6 +169,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
             $start = $e->getLine() - 4;
             $lines = array_slice($lines, $start < 0 ? 0 : $start, 7);
         } else {
+            $filePath = $this->normalizeFilePath($filePath);
             $lines = array("Cannot open the file ($filePath) in which the exception occurred ");
         }
 


### PR DESCRIPTION
avoid sending `traceAsString` when already html trace exists, it is not necessary to send both at the same time
https://github.com/maximebf/php-debugbar/blob/30f65f18f7ac086255a77a079f8e0dcdd35e828e/src/DebugBar/Resources/widgets.js#L580-L583
remove base path from trace paths
![image](https://github.com/maximebf/php-debugbar/assets/79208641/d638c8d4-51a6-42fd-aba1-890f438c546d)
![image](https://github.com/maximebf/php-debugbar/assets/79208641/43f3ff50-aac1-4689-a814-41f50c33e811)
Closes #555