### PR TITLE
(fix)preload formatter, avoids unexpected jumps on timeline

### DIFF
--- a/src/DebugBar/DataCollector/TimeDataCollector.php
+++ b/src/DebugBar/DataCollector/TimeDataCollector.php
@@ -56,6 +56,7 @@ class TimeDataCollector extends DataCollector implements Renderable
             }
         }
         $this->requestStartTime = (float)$requestStartTime;
+        static::getDefaultDataFormatter(); // initializes formatter for lineal timeline
     }
 
     /**


### PR DESCRIPTION
Closes #449
![image](https://github.com/maximebf/php-debugbar/assets/4933954/ad7dbb38-8bdd-47ed-8cb7-358ab5517f89)


https://github.com/maximebf/php-debugbar/blob/30f65f18f7ac086255a77a079f8e0dcdd35e828e/src/DebugBar/DataFormatter/DataFormatter.php#L25-L29

Global `DataFormatter` creates instances of `VarCloner, CliDumper`, this creates a unexpected jump on time line 
This PR preloads `DataFormatter` before measuring, that allows displaying  a consecutive waterfall
https://github.com/maximebf/php-debugbar/blob/30f65f18f7ac086255a77a079f8e0dcdd35e828e/src/DebugBar/DataCollector/DataCollector.php#L46-L52