### PR TITLE
(fix) update `formatDuration` port on timeline widget

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -433,8 +433,10 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 var formatDuration = function(seconds) {
                     if (seconds < 0.001)
                         return (seconds * 1000000).toFixed() + 'μs';
-                    else if (seconds < 1)
+                    else if (seconds < 0.1)
                         return (seconds * 1000).toFixed(2) + 'ms';
+                    else if (seconds < 1)
+                        return (seconds * 1000).toFixed() + 'ms';
                     return (seconds).toFixed(2) +  's';
                 };
 


### PR DESCRIPTION
[40f3755 _Skip decimals if < 100ms_](https://github.com/maximebf/php-debugbar/commit/40f375504a4dd8e59f779c3f3cac524777ddcde5)

https://github.com/maximebf/php-debugbar/blob/376ff32ee50c2c24cebd16ccb5a30c647e9b3c6d/src/DebugBar/Resources/widgets.js#L432-L439
https://github.com/maximebf/php-debugbar/blob/30f65f18f7ac086255a77a079f8e0dcdd35e828e/src/DebugBar/DataFormatter/DataFormatter.php#L57-L67
