### PR TITLE
(fix) editor ajax template links

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -128,7 +128,10 @@ abstract class DataCollector implements DataCollectorInterface
             }
         }
 
-        $url = strtr($this->getXdebugLinkTemplate(), ['%f' => $file, '%l' => $line]);
+        $url = strtr($this->getXdebugLinkTemplate(), [
+            '%f' => rawurlencode(str_replace('\\', '/', $file)),
+            '%l' => rawurlencode((string) $line),
+        ]);
         if ($url) {
             return ['url' => $url, 'ajax' => $this->getXdebugShouldUseAjax()];
         }
@@ -230,11 +233,11 @@ abstract class DataCollector implements DataCollectorInterface
             'emacs' => 'emacs://open?url=file://%f&line=%l',
             'macvim' => 'mvim://open/?url=file://%f&line=%l',
             'phpstorm' => 'phpstorm://open?file=%f&line=%l',
-            'phpstorm-remote' => 'javascript:let r=new XMLHttpRequest;' .
-                'r.open("get","http://localhost:63342/api/file/%f:%l");r.send()',
+            'phpstorm-remote' => 'javascript:(()=>{let r=new XMLHttpRequest;' .
+                'r.open(\'get\',\'http://localhost:63342/api/file/%f:%l\');r.send();})()',
             'idea' => 'idea://open?file=%f&line=%l',
-            'idea-remote' => 'javascript:let r=new XMLHttpRequest;' .
-                'r.open("get","http://localhost:63342/api/file/?file=%f&line=%l");r.send()',
+            'idea-remote' => 'javascript:(()=>{let r=new XMLHttpRequest;' .
+                'r.open(\'get\',\'http://localhost:63342/api/file/?file=%f&line=%l\');r.send();})()',
             'vscode' => 'vscode://file/%f:%l',
             'vscode-insiders' => 'vscode-insiders://file/%f:%l',
             'vscode-remote' => 'vscode://vscode-remote/%f:%l',


### PR DESCRIPTION
- `str_replace('\\', '/', $url)` fix editor links when local site replacement is windows os
- `" "` breaks html attribute on ajax template links, replaced with `\' \'`
- on second click throws `r is already declared` on ajax template links, now javascript is encapsulated in a function
- `rawurlencode` added for file paths

**UPDATE:**
I did a little research, seems like file path must be url encoded, look
[spatie/ignition/hooks/useEditorUrl.ts#L36](https://github.com/spatie/ignition-ui/blob/3c5a35b71ee516272f7e6e55b33c8cc0e26ac6dc/src/hooks/useEditorUrl.ts#L36)
[Whoops/Handler/PrettyPageHandler.php#L524-L525](https://github.com/filp/whoops/blob/c83e88a30524f9360b11f585f71e6b17313b7187/src/Whoops/Handler/PrettyPageHandler.php#L524-L525)
