### PR TITLE
Create ObjectCountCollector for count class/objects

### DIFF
--- a/demo/index.php
+++ b/demo/index.php
@@ -16,6 +16,12 @@ $debugbar['messages']->addMessage('world', 'warning');
 $debugbar['messages']->addMessage(array('toto' => array('titi', 'tata')));
 $debugbar['messages']->addMessage('oups', 'error');
 
+$classDemo = array('FirstClass', 'SecondClass', 'ThirdClass');
+$debugbar->addCollector(new \DebugBar\DataCollector\ObjectCountCollector());
+for ($i = 0; $i <=20; $i++) {
+    $debugbar['counter']->countClass($classDemo[rand(0, 2)]);
+}
+
 $debugbar['time']->startMeasure('render');
 
 render_demo_page(function() {

--- a/src/DebugBar/DataCollector/ObjectCountCollector.php
+++ b/src/DebugBar/DataCollector/ObjectCountCollector.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace DebugBar\DataCollector;
+
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\DataCollectorInterface;
+use DebugBar\DataCollector\Renderable;
+
+/**
+ * Collector for hit counts.
+ */
+class ObjectCountCollector extends DataCollector implements DataCollectorInterface, Renderable
+{
+    /** @var string */
+    private $name;
+    /** @var string */
+    private $icon;
+    /** @var int */
+    protected $classCount = 0;
+    /** @var array */
+    protected $classList = [];
+
+    /**
+     * @param string $name
+     * @param string $icon
+     */
+    public function __construct($name = 'counter', $icon = 'cubes')
+    {
+        $this->name = $name;
+        $this->icon = $icon;
+    }
+
+    /**
+     * @param string|mixed $class
+     */
+    public function countClass($class) {
+        if (! is_string($class)) {
+            $class = get_class($class);
+        }
+
+        $this->classList[$class] = ($this->classList[$class] ?? 0) + 1;
+        $this->classCount++;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function collect()
+    {
+        ksort($this->classList, SORT_NUMERIC);
+
+        if (! $this->getXdebugLinkTemplate()) {
+            return ['data' => array_reverse($this->classList), 'count' => $this->classCount];
+        }
+
+        $data = [];
+        foreach (array_reverse($this->classList) as $class => $count) {
+            $reflector = class_exists($class) ? new \ReflectionClass($class) : null;
+
+            if ($reflector && $link = $this->getXdebugLink($reflector->getFileName())) {
+                $data[$class . '<a href="' . $link['url'] . '" class="phpdebugbar-widgets-editor-link"></a>'] = $count;
+            } else {
+                $data[$class] = $count;
+            }
+        }
+
+        return ['data' => $data, 'count' => $this->classCount];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWidgets()
+    {
+        $name = $this->getName();
+
+        return [
+            "$name" => [
+                'icon' => $this->icon,
+                'widget' => 'PhpDebugBar.Widgets.HtmlVariableListWidget',
+                'map' => "$name.data",
+                'default' => '{}'
+            ],
+            "$name:badge" => [
+                'map' => "$name.count",
+                'default' => 0
+            ]
+        ];
+    }
+}

--- a/src/DebugBar/DataCollector/ObjectCountCollector.php
+++ b/src/DebugBar/DataCollector/ObjectCountCollector.php
@@ -32,14 +32,15 @@ class ObjectCountCollector extends DataCollector implements DataCollectorInterfa
 
     /**
      * @param string|mixed $class
+     * @param int $count
      */
-    public function countClass($class) {
+    public function countClass($class, $count = 1) {
         if (! is_string($class)) {
             $class = get_class($class);
         }
 
-        $this->classList[$class] = ($this->classList[$class] ?? 0) + 1;
-        $this->classCount++;
+        $this->classList[$class] = ($this->classList[$class] ?? 0) + $count;
+        $this->classCount += $count;
     }
 
     /**
@@ -47,14 +48,14 @@ class ObjectCountCollector extends DataCollector implements DataCollectorInterfa
      */
     public function collect()
     {
-        ksort($this->classList, SORT_NUMERIC);
+        arsort($this->classList, SORT_NUMERIC);
 
         if (! $this->getXdebugLinkTemplate()) {
-            return ['data' => array_reverse($this->classList), 'count' => $this->classCount];
+            return ['data' => $this->classList, 'count' => $this->classCount, 'is_counter' => true];
         }
 
         $data = [];
-        foreach (array_reverse($this->classList) as $class => $count) {
+        foreach ($this->classList as $class => $count) {
             $reflector = class_exists($class) ? new \ReflectionClass($class) : null;
 
             if ($reflector && $link = $this->getXdebugLink($reflector->getFileName())) {
@@ -64,7 +65,7 @@ class ObjectCountCollector extends DataCollector implements DataCollectorInterfa
             }
         }
 
-        return ['data' => $data, 'count' => $this->classCount];
+        return ['data' => $data, 'count' => $this->classCount, 'is_counter' => true];
     }
 
     /**

--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -146,6 +146,17 @@ dl.phpdebugbar-widgets-kvlist {
     cursor: pointer;
     min-height: 17px;
   }
+  .phpdebugbar-widgets-kvlist .phpdebugbar-widgets-editor-link {
+    margin-left: 8px;
+    color: #888;
+  }
+  .phpdebugbar-widgets-kvlist .phpdebugbar-widgets-editor-link:before {
+    content: "\f08e";
+    font-family: PhpDebugbarFontAwesome;
+    margin-left: 4px;
+    margin-right: 4px;
+    font-size: 12px;
+  }
 
 /* -------------------------------------- */
 


### PR DESCRIPTION
![image](https://github.com/maximebf/php-debugbar/assets/4933954/8d789146-f6d7-4968-bd92-49b34c5f2889)
- Allows to easily add a counter for events/classes/hits and others
- Supports xdebug editor links
- On https://github.com/barryvdh/laravel-debugbar/pull/1470, all the [ModelsCollector](https://github.com/barryvdh/laravel-debugbar/blob/master/src/DataCollector/ModelsCollector.php) code is repeated, With `ObjectCountCollector` we could just do
```php
$debugbar->addCollector(new \DebugBar\DataCollector\ObjectCountCollector('jobs', 'briefcase'));
app('events')->listen(\Illuminate\Queue\Events\JobQueued::class, function ($event) use($debugbar) {
    $debugbar['jobs']->countClass($event->job);
});
```
- [ModelsCollector](https://github.com/barryvdh/laravel-debugbar/blob/master/src/DataCollector/ModelsCollector.php) could be removed, and [LaravelDebugbar.php#L429-L430](https://github.com/barryvdh/laravel-debugbar/blob/b7362410434d7f1155e0729e3a75c83384d3b699/src/LaravelDebugbar.php#L429-L430) could be replaced by
```php
$this->addCollector(new \DebugBar\DataCollector\ObjectCountCollector('models')));
$this->app['events']->listen('eloquent.retrieved:*', function ($event, $models) {
    foreach (array_filter($models) as $model) {
        $this['models']->countClass($model);
    }
});
```

---
maybe everything could be unified as `counter`, no longer as `models`/`jobs`;
and on `config/debugbar.php`, `counter` will has properties 
```php
'counter' => [
    'models' => true,
    'jobs' => true, 
    //other counters could be added
],
```

---
**UPDATE:** Demo added
![image](https://github.com/maximebf/php-debugbar/assets/4933954/9b2fcaae-8e26-4a36-9a56-fca394d18f60)
