### PR TITLE
Show memory with default precision 2

### DIFF
--- a/src/DebugBar/DataCollector/MemoryCollector.php
+++ b/src/DebugBar/DataCollector/MemoryCollector.php
@@ -82,7 +82,7 @@ class MemoryCollector extends DataCollector implements Renderable
         $this->updatePeakUsage();
         return array(
             'peak_usage' => $this->getPeakUsage(),
-            'peak_usage_str' => $this->getDataFormatter()->formatBytes($this->getPeakUsage(), 0)
+            'peak_usage_str' => $this->getDataFormatter()->formatBytes($this->getPeakUsage())
         );
     }
 


### PR DESCRIPTION
It's more accurate
![image](https://github.com/maximebf/php-debugbar/assets/79208489/b95a9daa-29a7-4109-9ba4-c3e9d7895e60)
