### PR TITLE
Refactor DataCollector html dumper to a trait

### DIFF
--- a/src/DebugBar/DataCollector/ConfigCollector.php
+++ b/src/DebugBar/DataCollector/ConfigCollector.php
@@ -19,34 +19,6 @@ class ConfigCollector extends DataCollector implements Renderable, AssetProvider
 
     protected $data;
 
-    // The HTML var dumper requires debug bar users to support the new inline assets, which not all
-    // may support yet - so return false by default for now.
-    protected $useHtmlVarDumper = false;
-
-    /**
-     * Sets a flag indicating whether the Symfony HtmlDumper will be used to dump variables for
-     * rich variable rendering.
-     *
-     * @param bool $value
-     * @return $this
-     */
-    public function useHtmlVarDumper($value = true)
-    {
-        $this->useHtmlVarDumper = $value;
-        return $this;
-    }
-
-    /**
-     * Indicates whether the Symfony HtmlDumper will be used to dump variables for rich variable
-     * rendering.
-     *
-     * @return mixed
-     */
-    public function isHtmlVarDumperUsed()
-    {
-        return $this->useHtmlVarDumper;
-    }
-
     /**
      * @param array  $data
      * @param string $name

--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -10,69 +10,21 @@
 
 namespace DebugBar\DataCollector;
 
-use DebugBar\DataFormatter\DataFormatter;
-use DebugBar\DataFormatter\DataFormatterInterface;
-use DebugBar\DataFormatter\DebugBarVarDumper;
+use DebugBar\DataFormatter\HasDataFormatter;
 
 /**
  * Abstract class for data collectors
  */
 abstract class DataCollector implements DataCollectorInterface
 {
-    private static $defaultDataFormatter;
-    private static $defaultVarDumper;
+    use HasDataFormatter;
 
-    protected $dataFormater;
-    protected $varDumper;
+    public static $defaultDataFormatter;
+    public static $defaultVarDumper;
+
     protected $xdebugLinkTemplate = '';
     protected $xdebugShouldUseAjax = false;
     protected $xdebugReplacements = array();
-
-    /**
-     * Sets the default data formater instance used by all collectors subclassing this class
-     *
-     * @param DataFormatterInterface $formater
-     */
-    public static function setDefaultDataFormatter(DataFormatterInterface $formater)
-    {
-        self::$defaultDataFormatter = $formater;
-    }
-
-    /**
-     * Returns the default data formater
-     *
-     * @return DataFormatterInterface
-     */
-    public static function getDefaultDataFormatter()
-    {
-        if (self::$defaultDataFormatter === null) {
-            self::$defaultDataFormatter = new DataFormatter();
-        }
-        return self::$defaultDataFormatter;
-    }
-
-    /**
-     * Sets the data formater instance used by this collector
-     *
-     * @param DataFormatterInterface $formater
-     * @return $this
-     */
-    public function setDataFormatter(DataFormatterInterface $formater)
-    {
-        $this->dataFormater = $formater;
-        return $this;
-    }
-
-    /**
-     * @return DataFormatterInterface
-     */
-    public function getDataFormatter()
-    {
-        if ($this->dataFormater === null) {
-            $this->dataFormater = self::getDefaultDataFormatter();
-        }
-        return $this->dataFormater;
-    }
 
     /**
      * Shorten the file path by removing the xdebug path replacements
@@ -132,79 +84,6 @@ abstract class DataCollector implements DataCollectorInterface
         if ($url) {
             return ['url' => $url, 'ajax' => $this->getXdebugShouldUseAjax()];
         }
-    }
-  
-    /**  
-     * Sets the default variable dumper used by all collectors subclassing this class
-     *
-     * @param DebugBarVarDumper $varDumper
-     */
-    public static function setDefaultVarDumper(DebugBarVarDumper $varDumper)
-    {
-        self::$defaultVarDumper = $varDumper;
-    }
-
-    /**
-     * Returns the default variable dumper
-     *
-     * @return DebugBarVarDumper
-     */
-    public static function getDefaultVarDumper()
-    {
-        if (self::$defaultVarDumper === null) {
-            self::$defaultVarDumper = new DebugBarVarDumper();
-        }
-        return self::$defaultVarDumper;
-    }
-
-    /**
-     * Sets the variable dumper instance used by this collector
-     *
-     * @param DebugBarVarDumper $varDumper
-     * @return $this
-     */
-    public function setVarDumper(DebugBarVarDumper $varDumper)
-    {
-        $this->varDumper = $varDumper;
-        return $this;
-    }
-
-    /**
-     * Gets the variable dumper instance used by this collector; note that collectors using this
-     * instance need to be sure to return the static assets provided by the variable dumper.
-     *
-     * @return DebugBarVarDumper
-     */
-    public function getVarDumper()
-    {
-        if ($this->varDumper === null) {
-            $this->varDumper = self::getDefaultVarDumper();
-        }
-        return $this->varDumper;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function formatVar($var)
-    {
-        return $this->getDataFormatter()->formatVar($var);
-    }
-
-    /**
-     * @deprecated
-     */
-    public function formatDuration($seconds)
-    {
-        return $this->getDataFormatter()->formatDuration($seconds);
-    }
-
-    /**
-     * @deprecated
-     */
-    public function formatBytes($size, $precision = 2)
-    {
-        return $this->getDataFormatter()->formatBytes($size, $precision);
     }
 
     /**

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -21,10 +21,6 @@ class ExceptionsCollector extends DataCollector implements Renderable
     protected $exceptions = array();
     protected $chainExceptions = false;
 
-    // The HTML var dumper requires debug bar users to support the new inline assets, which not all
-    // may support yet - so return false by default for now.
-    protected $useHtmlVarDumper = false;
-
     /**
      * Adds an exception to be profiled in the debug bar
      *
@@ -67,30 +63,6 @@ class ExceptionsCollector extends DataCollector implements Renderable
     public function getExceptions()
     {
         return $this->exceptions;
-    }
-
-    /**
-     * Sets a flag indicating whether the Symfony HtmlDumper will be used to dump variables for
-     * rich variable rendering.
-     *
-     * @param bool $value
-     * @return $this
-     */
-    public function useHtmlVarDumper($value = true)
-    {
-        $this->useHtmlVarDumper = $value;
-        return $this;
-    }
-
-    /**
-     * Indicates whether the Symfony HtmlDumper will be used to dump variables for rich variable
-     * rendering.
-     *
-     * @return mixed
-     */
-    public function isHtmlVarDumperUsed()
-    {
-        return $this->useHtmlVarDumper;
     }
 
     public function collect()

--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -11,27 +11,20 @@
 namespace DebugBar\DataCollector;
 
 use Psr\Log\AbstractLogger;
-use DebugBar\DataFormatter\DataFormatterInterface;
-use DebugBar\DataFormatter\DebugBarVarDumper;
+use DebugBar\DataFormatter\HasDataFormatter;
 
 /**
  * Provides a way to log messages
  */
 class MessagesCollector extends AbstractLogger implements DataCollectorInterface, MessagesAggregateInterface, Renderable, AssetProvider
 {
+    use HasDataFormatter;
+
     protected $name;
 
     protected $messages = array();
 
     protected $aggregates = array();
-
-    protected $dataFormater;
-
-    protected $varDumper;
-
-    // The HTML var dumper requires debug bar users to support the new inline assets, which not all
-    // may support yet - so return false by default for now.
-    protected $useHtmlVarDumper = false;
 
     /**
      * @param string $name
@@ -39,79 +32,6 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
     public function __construct($name = 'messages')
     {
         $this->name = $name;
-    }
-
-    /**
-     * Sets the data formater instance used by this collector
-     *
-     * @param DataFormatterInterface $formater
-     * @return $this
-     */
-    public function setDataFormatter(DataFormatterInterface $formater)
-    {
-        $this->dataFormater = $formater;
-        return $this;
-    }
-
-    /**
-     * @return DataFormatterInterface
-     */
-    public function getDataFormatter()
-    {
-        if ($this->dataFormater === null) {
-            $this->dataFormater = DataCollector::getDefaultDataFormatter();
-        }
-        return $this->dataFormater;
-    }
-
-    /**
-     * Sets the variable dumper instance used by this collector
-     *
-     * @param DebugBarVarDumper $varDumper
-     * @return $this
-     */
-    public function setVarDumper(DebugBarVarDumper $varDumper)
-    {
-        $this->varDumper = $varDumper;
-        return $this;
-    }
-
-    /**
-     * Gets the variable dumper instance used by this collector
-     *
-     * @return DebugBarVarDumper
-     */
-    public function getVarDumper()
-    {
-        if ($this->varDumper === null) {
-            $this->varDumper = DataCollector::getDefaultVarDumper();
-        }
-        return $this->varDumper;
-    }
-
-    /**
-     * Sets a flag indicating whether the Symfony HtmlDumper will be used to dump variables for
-     * rich variable rendering.  Be sure to set this flag before logging any messages for the
-     * first time.
-     *
-     * @param bool $value
-     * @return $this
-     */
-    public function useHtmlVarDumper($value = true)
-    {
-        $this->useHtmlVarDumper = $value;
-        return $this;
-    }
-
-    /**
-     * Indicates whether the Symfony HtmlDumper will be used to dump variables for rich variable
-     * rendering.
-     *
-     * @return mixed
-     */
-    public function isHtmlVarDumperUsed()
-    {
-        return $this->useHtmlVarDumper;
     }
 
     /**

--- a/src/DebugBar/DataCollector/RequestDataCollector.php
+++ b/src/DebugBar/DataCollector/RequestDataCollector.php
@@ -15,34 +15,6 @@ namespace DebugBar\DataCollector;
  */
 class RequestDataCollector extends DataCollector implements Renderable, AssetProvider
 {
-    // The HTML var dumper requires debug bar users to support the new inline assets, which not all
-    // may support yet - so return false by default for now.
-    protected $useHtmlVarDumper = false;
-
-    /**
-     * Sets a flag indicating whether the Symfony HtmlDumper will be used to dump variables for
-     * rich variable rendering.
-     *
-     * @param bool $value
-     * @return $this
-     */
-    public function useHtmlVarDumper($value = true)
-    {
-        $this->useHtmlVarDumper = $value;
-        return $this;
-    }
-
-    /**
-     * Indicates whether the Symfony HtmlDumper will be used to dump variables for rich variable
-     * rendering.
-     *
-     * @return mixed
-     */
-    public function isHtmlVarDumperUsed()
-    {
-        return $this->useHtmlVarDumper;
-    }
-
     /**
      * @return array
      */

--- a/src/DebugBar/DataFormatter/HasDataFormatter.php
+++ b/src/DebugBar/DataFormatter/HasDataFormatter.php
@@ -1,0 +1,164 @@
+<?php
+/*
+ * This file is part of the DebugBar package.
+ *
+ * (c) 2013 Maxime Bouroumeau-Fuseau
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DebugBar\DataFormatter;
+
+use DebugBar\DataCollector\DataCollector;
+
+trait HasDataFormatter
+{
+    // The HTML var dumper requires debug bar users to support the new inline assets, which not all
+    // may support yet - so return false by default for now.
+    protected $useHtmlVarDumper = false;
+    protected $dataFormater;
+    protected $varDumper;
+
+    /**
+     * Sets a flag indicating whether the Symfony HtmlDumper will be used to dump variables for
+     * rich variable rendering.
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function useHtmlVarDumper($value = true)
+    {
+        $this->useHtmlVarDumper = $value;
+        return $this;
+    }
+
+    /**
+     * Indicates whether the Symfony HtmlDumper will be used to dump variables for rich variable
+     * rendering.
+     *
+     * @return mixed
+     */
+    public function isHtmlVarDumperUsed()
+    {
+        return $this->useHtmlVarDumper;
+    }
+
+    /**
+     * Sets the default data formater instance used by all collectors subclassing this class
+     *
+     * @param DataFormatterInterface $formater
+     */
+    public static function setDefaultDataFormatter(DataFormatterInterface $formater)
+    {
+        DataCollector::$defaultDataFormatter = $formater;
+    }
+
+    /**
+     * Returns the default data formater
+     *
+     * @return DataFormatterInterface
+     */
+    public static function getDefaultDataFormatter()
+    {
+        if (DataCollector::$defaultDataFormatter === null) {
+            DataCollector::$defaultDataFormatter = new DataFormatter();
+        }
+        return DataCollector::$defaultDataFormatter;
+    }
+
+    /**
+     * Sets the data formater instance used by this collector
+     *
+     * @param DataFormatterInterface $formater
+     * @return $this
+     */
+    public function setDataFormatter(DataFormatterInterface $formater)
+    {
+        $this->dataFormater = $formater;
+        return $this;
+    }
+
+    /**
+     * @return DataFormatterInterface
+     */
+    public function getDataFormatter()
+    {
+        if ($this->dataFormater === null) {
+            $this->dataFormater = DataCollector::getDefaultDataFormatter();
+        }
+        return $this->dataFormater;
+    }
+    /**
+     * Sets the default variable dumper used by all collectors subclassing this class
+     *
+     * @param DebugBarVarDumper $varDumper
+     */
+    public static function setDefaultVarDumper(DebugBarVarDumper $varDumper)
+    {
+        DataCollector::$defaultVarDumper = $varDumper;
+    }
+
+    /**
+     * Returns the default variable dumper
+     *
+     * @return DebugBarVarDumper
+     */
+    public static function getDefaultVarDumper()
+    {
+        if (DataCollector::$defaultVarDumper === null) {
+            DataCollector::$defaultVarDumper = new DebugBarVarDumper();
+        }
+        return DataCollector::$defaultVarDumper;
+    }
+
+    /**
+     * Sets the variable dumper instance used by this collector
+     *
+     * @param DebugBarVarDumper $varDumper
+     * @return $this
+     */
+    public function setVarDumper(DebugBarVarDumper $varDumper)
+    {
+        $this->varDumper = $varDumper;
+        return $this;
+    }
+
+    /**
+     * Gets the variable dumper instance used by this collector; note that collectors using this
+     * instance need to be sure to return the static assets provided by the variable dumper.
+     *
+     * @return DebugBarVarDumper
+     */
+    public function getVarDumper()
+    {
+        if ($this->varDumper === null) {
+            $this->varDumper = DataCollector::getDefaultVarDumper();
+        }
+        return $this->varDumper;
+    }
+
+    /**
+     * @deprecated
+     */
+    public function formatVar($var)
+    {
+        return $this->getDataFormatter()->formatVar($var);
+    }
+
+    /**
+     * @deprecated
+     */
+    public function formatDuration($seconds)
+    {
+        return $this->getDataFormatter()->formatDuration($seconds);
+    }
+
+    /**
+     * @deprecated
+     */
+    public function formatBytes($size, $precision = 2)
+    {
+        return $this->getDataFormatter()->formatBytes($size, $precision);
+    }
+}


### PR DESCRIPTION
@barryvdh I noticed that the same code is repeated many times,
Wouldn't it be better to move it to a trait?
It would be more readable and more organized
everything would continue working the same
~I don't know if it will be a breaking change~ It's not, **DEMO:** https://onlinephp.io/c/b3a7d