### PR TITLE
Upgrade PDOCollector and queries widget

### DIFF
--- a/demo/pdo.php
+++ b/demo/pdo.php
@@ -7,6 +7,7 @@ use DebugBar\DataCollector\PDO\PDOCollector;
 
 $pdo = new TraceablePDO(new PDO('sqlite::memory:'));
 $debugbar->addCollector(new PDOCollector($pdo));
+$debugbar['pdo']->setDurationBackground();
 
 $pdo->exec('create table users (name varchar)');
 $stmt = $pdo->prepare('insert into users (name) values (?)');

--- a/src/DebugBar/DataCollector/PDO/PDOCollector.php
+++ b/src/DebugBar/DataCollector/PDO/PDOCollector.php
@@ -20,6 +20,8 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
 
     protected $sqlQuotationChar = '<>';
 
+    protected $durationBackground = false;
+
     /**
      * @param \PDO $pdo
      * @param TimeDataCollector $timeCollector
@@ -41,6 +43,16 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
     {
         $this->renderSqlWithParams = $enabled;
         $this->sqlQuotationChar = $quotationChar;
+    }
+
+    /**
+     * Enable/disable the shaded duration background on queries
+     *
+     * @param  bool $enabled
+     */
+    public function setDurationBackground($enabled = true)
+    {
+        $this->durationBackground = $enabled;
     }
 
     /**
@@ -156,11 +168,29 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
             }
         }
 
+        $totalTime = $pdo->getAccumulatedStatementsDuration();
+        if ($this->durationBackground && $totalTime > 0) {
+            // For showing background measure on Queries tab
+            $start_percent = 0;
+            foreach ($stmts as $i => $stmt) {
+                if (!isset($stmt['duration'])) {
+                    continue;
+                }
+
+                $width_percent = $stmt['duration'] / $totalTime * 100;
+                $stmts[$i] = array_merge($stmt, [
+                    'start_percent' => round($start_percent, 3),
+                    'width_percent' => round($width_percent, 3),
+                ]);
+                $start_percent += $width_percent;
+            }
+        }
+
         return array(
             'nb_statements' => count($stmts),
             'nb_failed_statements' => count($pdo->getFailedExecutedStatements()),
-            'accumulated_duration' => $pdo->getAccumulatedStatementsDuration(),
-            'accumulated_duration_str' => $this->getDataFormatter()->formatDuration($pdo->getAccumulatedStatementsDuration()),
+            'accumulated_duration' => $totalTime,
+            'accumulated_duration_str' => $this->getDataFormatter()->formatDuration($totalTime),
             'memory_usage' => $pdo->getMemoryUsage(),
             'memory_usage_str' => $this->getDataFormatter()->formatBytes($pdo->getPeakMemoryUsage()),
             'peak_memory_usage' => $pdo->getPeakMemoryUsage(),

--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.css
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.css
@@ -34,7 +34,8 @@ div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-duration:before,
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-memory:before,
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-row-count:before,
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-copy-clipboard:before,
-div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-stmt-id:before {
+div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-stmt-id:before,
+div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-editor-link:before {
   font-family: PhpDebugbarFontAwesome;
   margin-right: 4px;
   font-size: 12px;
@@ -56,6 +57,15 @@ div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-stmt-id:before {
 }
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-copy-clipboard:before {
   content: "\f0c5";
+}
+div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-editor-link:before {
+  content: "\f08e";
+}
+div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-editor-link {
+  color: #888;
+}
+div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-editor-link:hover {
+  color: #aaaaaa;
 }
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params {
   display: none;
@@ -114,5 +124,30 @@ div.phpdebugbar-widgets-sqlqueries div.phpdebugbar-widgets-toolbar a.phpdebugbar
 }
 div.phpdebugbar-widgets-sqlqueries div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter.phpdebugbar-widgets-excluded {
   background: #eee;
+  color: #888;
+}
+div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-duplicates {
+  font-weight: bold;
+  text-decoration: underline;
+}
+div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item div.phpdebugbar-widgets-bg-measure {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+}
+div.phpdebugbar-widgets-sqlqueries div.phpdebugbar-widgets-bg-measure div.phpdebugbar-widgets-value {
+  position: absolute;
+  height: 100%;
+  opacity: 0.2;
+  background: red;
+}
+div.phpdebugbar-widgets-sqlqueries td.phpdebugbar-widgets-value li.phpdebugbar-widgets-table-list-item {
+  text-align: left;
+  padding-left: 6px;
+}
+div.phpdebugbar-widgets-sqlqueries .phpdebugbar-text-muted {
   color: #888;
 }


### PR DESCRIPTION
Bring all the `PDOCollector/SQLQueriesWidget` fixes and features from [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) to [maximebf/php-debugbar](https://github.com/maximebf/php-debugbar)
All these functionalities have been tested for a long time and have not presented any problems.

- https://github.com/barryvdh/laravel-debugbar/commit/eb61c2f6c5b61a969e66bc1df36ef5568ecad9a0 Show duration as a progressbar on a background
- https://github.com/barryvdh/laravel-debugbar/commit/70b89754913fd89fef16d0170a91dbc2a5cd633a Option to toggle query background progressbar on/off
- https://github.com/barryvdh/laravel-debugbar/commit/5d4ee5c21ede2a3f7ae092937aa2cff828fc1daf Show only duplicated queries button on debugbar tab
- https://github.com/barryvdh/laravel-debugbar/commit/99abc7fc49e7440346f7b6eee54e397f62a4c981 Queries on different databases aren't duplicates
- https://github.com/barryvdh/laravel-debugbar/commit/0d552cfdd703fc72c7b1a70c6f4d172794e5c48d HTML rendering of query extra metadata
- xdebug_link support

![image](https://github.com/maximebf/php-debugbar/assets/4933954/c4df1573-8cd5-47b2-84c6-c28d7f4d0e78)
