### PR TITLE
Add names to inputs

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -537,7 +537,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
             });
 
             // select box for data sets
-            this.$datasets = $('<select />').addClass(csscls('datasets-switcher')).appendTo(this.$headerRight);
+            this.$datasets = $('<select />').addClass(csscls('datasets-switcher')).attr('name', 'datasets-switcher')
+                .appendTo(this.$headerRight);
             this.$datasets.change(function() {
                 self.dataChangeHandler(self.datasets[this.value]);
                 self.showTab();

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -353,7 +353,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.$list.$el.appendTo(this.$el);
             this.$toolbar = $('<div><i class="phpdebugbar-fa phpdebugbar-fa-search"></i></div>').addClass(csscls('toolbar')).appendTo(this.$el);
 
-            $('<input type="text" aria-label="Search" placeholder="Search" />')
+            $('<input type="text" name="search" aria-label="Search" placeholder="Search" />')
                 .on('change', function() { self.set('search', this.value); })
                 .appendTo(this.$toolbar);
 


### PR DESCRIPTION
Add name to the <input> and <select> fields

This is to remove certain Chrome "improvement" notices like:

"A form field element has neither an id nor a name attribute. This might prevent the browser from correctly autofilling the form."



Note: Some still remain but as far as I can tell those are coming from VarDumper not this repo. 