### PR TITLE
Added catch to promise for window.fetch wrapper

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1174,6 +1174,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
                 promise.then(function (response) {
                     self.handle(response);
+                }).catch(function(reason) {
+                    // Fetch request failed or aborted via AbortController.abort().
+                    // Catch is required to not trigger React's error handler.
                 });
 
                 return promise;


### PR DESCRIPTION
Added catch to promise for window.fetch wrapper to avoid "Uncaught (in promise) DOMException: The user aborted a request." errors.

 This is required to not trigger React's error handler which looks very confusing.

Related issue: https://github.com/barryvdh/laravel-debugbar/issues/1348