### PR TITLE
fix open_basedir restriction error

### DIFF
--- a/src/DebugBar/DataCollector/DataCollector.php
+++ b/src/DebugBar/DataCollector/DataCollector.php
@@ -86,7 +86,7 @@ abstract class DataCollector implements DataCollectorInterface
             return '';
         }
 
-        if (file_exists($file)) {
+        if (@file_exists($file)) {
             $file = realpath($file);
         }
 
@@ -117,7 +117,7 @@ abstract class DataCollector implements DataCollectorInterface
             return null;
         }
 
-        if (file_exists($file)) {
+        if (@file_exists($file)) {
             $file = realpath($file);
         }
 

--- a/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/tests/DebugBar/Tests/DataCollector/TimeDataCollectorTest.php
@@ -53,6 +53,7 @@ class TimeDataCollectorTest extends DebugBarTestCase
     public function testMeasure()
     {
         $returned = $this->c->measure('bar', function() {
+            usleep(50);
             return 'returnedValue';
         });
         $m = $this->c->getMeasures();


### PR DESCRIPTION
>The error that arises is:
>
>`file_exists(): open_basedir restriction in effect. File(...) is not within the allowed path(s): (PATH_TO_THE_SITE\)`

Closes #587