### PR TITLE
Fix file not exists by setting line default 1 on editor links

### DIFF
--- a/src/DebugBar/DataFormatter/HasXdebugLinks.php
+++ b/src/DebugBar/DataFormatter/HasXdebugLinks.php
@@ -55,7 +55,7 @@ trait HasXdebugLinks
      * @var bool     $ajax should be used to open the url instead of a normal links
      * }
      */
-    public function getXdebugLink($file, $line = null)
+    public function getXdebugLink($file, $line = 1)
     {
         if (empty($file)) {
             return null;

--- a/src/DebugBar/DataFormatter/HasXdebugLinks.php
+++ b/src/DebugBar/DataFormatter/HasXdebugLinks.php
@@ -74,7 +74,7 @@ trait HasXdebugLinks
 
         $url = strtr($this->getXdebugLinkTemplate(), [
             '%f' => rawurlencode(str_replace('\\', '/', $file)),
-            '%l' => rawurlencode((string) $line ?: ''),
+            '%l' => rawurlencode((string) $line ?: 1),
         ]);
         if ($url) {
             return [

--- a/src/DebugBar/DataFormatter/HasXdebugLinks.php
+++ b/src/DebugBar/DataFormatter/HasXdebugLinks.php
@@ -48,14 +48,14 @@ trait HasXdebugLinks
      * Get an Xdebug Link to a file
      *
      * @param string $file
-     * @param int    $line
+     * @param int|null $line
      *
      * @return array {
      * @var string   $url
      * @var bool     $ajax should be used to open the url instead of a normal links
      * }
      */
-    public function getXdebugLink($file, $line = 1)
+    public function getXdebugLink($file, $line = null)
     {
         if (empty($file)) {
             return null;


### PR DESCRIPTION
@barryvdh hi

in some editors something comes `home.blade.php:`, If there is no line number this generates an error 

![image](https://github.com/maximebf/php-debugbar/assets/79155632/46ae48c2-eadb-41be-8a03-468ab950cf66)

 add line 1 by default so that the editor can open the file, example: `home.blade.php:1` 


