### PR TITLE
Timeline measure params table hidden by default

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -486,7 +486,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         this.$el.append(li);
 
                         if (measure.params && !$.isEmptyObject(measure.params)) {
-                            var table = $('<table><tr><th colspan="2">Params</th></tr></table>').addClass(csscls('params')).appendTo(li);
+                            var table = $('<table><tr><th colspan="2">Params</th></tr></table>').hide().addClass(csscls('params')).appendTo(li);
                             for (var key in measure.params) {
                                 if (typeof measure.params[key] !== 'function') {
                                     table.append('<tr><td class="' + csscls('name') + '">' + key + '</td><td class="' + csscls('value') +


### PR DESCRIPTION
When Timeline measure item has params

- tab grows too much(vertically)
- This does not allow  to correctly observe the timeline waterfall, and you can't see each item

The functionality of clicking and showing the parameters table is maintained

On [laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) `Cache`/`Events` tabs you can see the problem, look:

**Without this PR:**
![image](https://github.com/maximebf/php-debugbar/assets/4933954/a24b3685-9913-4715-a5b1-71ae2414796a)
**With this PR:**
![image](https://github.com/maximebf/php-debugbar/assets/4933954/d485eeda-8bd1-4f2c-aef8-0ea1dcb47725)
**On clicking:**
![image](https://github.com/maximebf/php-debugbar/assets/4933954/255f5234-57cb-4848-acc1-515ae5fdb821)
