### PR TITLE
Avoid expanded values on MessagesCollector

### DIFF
--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -45,6 +45,22 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
     }
 
     /**
+     * @param string|null $messageHtml
+     * @param mixed $message
+     *
+     * @return string|null
+     */
+    protected function customizeMessageHtml($messageHtml, $message)
+    {
+        $pos = strpos((string) $messageHtml, 'sf-dump-expanded');
+        if ($pos !== false) {
+            $messageHtml = substr_replace($messageHtml, 'sf-dump-compact', $pos, 16);
+        }
+
+        return $messageHtml;
+    }
+
+    /**
      * Adds a message
      *
      * A message can be anything from an object to a string
@@ -81,7 +97,7 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
 
         $this->messages[] = array(
             'message' => $messageText,
-            'message_html' => $messageHtml,
+            'message_html' => $this->customizeMessageHtml($messageHtml, $message),
             'is_string' => $isString,
             'label' => $label,
             'time' => microtime(true),


### PR DESCRIPTION
When `isHtmlVarDumperUsed()` is false, we have this
![image](https://github.com/maximebf/php-debugbar/assets/79208489/369e50de-338f-4183-b4e5-a09ff1a86437)
But, when `isHtmlVarDumperUsed()` is true, all data is expanded by default
![image](https://github.com/maximebf/php-debugbar/assets/79208489/4fa0d51e-ce09-409e-aa32-6b8ae986b0df)
With this change, it is easier to find the log we are looking for, by the file, line, etc
![image](https://github.com/maximebf/php-debugbar/assets/79208489/dc332243-c1ac-48d2-b167-188e54067e1b)
Also as an independent method it is possible to make other customizations based on `$message` data, just by extending the class