### PR TITLE
Refactor to loader environment setter

### DIFF
--- a/src/DebugBar/Bridge/NamespacedTwigProfileCollector.php
+++ b/src/DebugBar/Bridge/NamespacedTwigProfileCollector.php
@@ -79,9 +79,18 @@ class NamespacedTwigProfileCollector extends DataCollector implements Renderable
     public function __construct(Profile $profile, $loaderOrEnv = null)
     {
         $this->profile = $profile;
+        $this->setLoaderOrEnv($loaderOrEnv);
+    }
+
+    /**
+     * @param LoaderInterface|Environment $loaderOrEnv
+     */
+    public function setLoaderOrEnv($loaderOrEnv)
+    {
         if ($loaderOrEnv instanceof Environment) {
             $loaderOrEnv = $loaderOrEnv->getLoader();
         }
+
         $this->loader = $loaderOrEnv;
     }
 


### PR DESCRIPTION
In some applications the environment is not accessible until an event such as the render is executed
With this option you can add this property when required
```php
$debugbar['twig']->setLoaderOrEnv($twig);
``` 