### PR TITLE
Do not click when selection is active

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -318,6 +318,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
                             prettyVal = null;
                         }
                         li.css('cursor', 'pointer').click(function () {
+                            if (window.getSelection().type == "Range") {
+                                return''
+                            }
                             if (val.hasClass(csscls('pretty'))) {
                                 val.text(m).removeClass(csscls('pretty'));
                             } else {

--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.js
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.js
@@ -161,6 +161,9 @@
                 if (table.find('tr').length) {
                     table.appendTo(li);
                     li.css('cursor', 'pointer').click(function() {
+                        if (window.getSelection().type == "Range") {
+                            return''
+                        }
                         if (table.is(':visible')) {
                             table.hide();
                         } else {


### PR DESCRIPTION
This could be added to more collectors probably, but basically: 
If a selection range is active, prevent the click behavior. Especially useful for thinks like copying paths etc.