### PR TITLE
Use xdebug_link in html variables

### DIFF
--- a/src/DebugBar/DataCollector/ObjectCountCollector.php
+++ b/src/DebugBar/DataCollector/ObjectCountCollector.php
@@ -59,7 +59,10 @@ class ObjectCountCollector extends DataCollector implements DataCollectorInterfa
             $reflector = class_exists($class) ? new \ReflectionClass($class) : null;
 
             if ($reflector && $link = $this->getXdebugLink($reflector->getFileName())) {
-                $data[$class . '<a href="' . $link['url'] . '" class="phpdebugbar-widgets-editor-link"></a>'] = $count;
+                $data[$class] = [
+                    'value' => $count,
+                    'xdebug_link' => $link,
+                ];
             } else {
                 $data[$class] = $count;
             }

--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -31,6 +31,7 @@ pre.phpdebugbar-widgets-code-block {
     text-align: right;
   }
 
+  .phpdebugbar-widgets-kvlist span.phpdebugbar-widgets-filename,
   li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-filename {
     display: block;
     font-style: italic;
@@ -39,7 +40,7 @@ pre.phpdebugbar-widgets-code-block {
     color: #888;
   }
 
-  li.phpdebugbar-widgets-list-item a.phpdebugbar-widgets-editor-link:hover {
+  a.phpdebugbar-widgets-editor-link:hover {
     color: #aaaaaa;
   }
 

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -218,7 +218,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
         itemRenderer: function(dt, dd, key, value) {
             $('<span />').attr('title', key).text(key).appendTo(dt);
 
-            var v = value;
+            var v = value && value.value || value;
             if (v && v.length > 100) {
                 v = v.substr(0, 100) + "...";
             }
@@ -251,7 +251,21 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
         itemRenderer: function(dt, dd, key, value) {
             $('<span />').attr('title', $('<i />').html(key || '').text()).html(key || '').appendTo(dt);
-            dd.html(value);
+            dd.html(value && value.value || value);
+
+            if (value && value.xdebug_link) {
+                var header = $('<span />').addClass(csscls('filename')).text(value.xdebug_link.filename + ( value.xdebug_link.line ? "#" + value.xdebug_link.line : ''));
+                if (value.xdebug_link) {
+                    if (value.xdebug_link.ajax) {
+                        $('<a title="' + value.xdebug_link.url + '"></a>').on('click', function () {
+                            $.ajax(value.xdebug_link.url);
+                        }).addClass(csscls('editor-link')).appendTo(header);
+                    } else {
+                        $('<a href="' + value.xdebug_link.url + '"></a>').addClass(csscls('editor-link')).appendTo(header);
+                    }
+                }
+                header.appendTo(dd);
+            }
         }
 
     });


### PR DESCRIPTION
Allow array to be used as value to make it easier to extend functionality. Fallback to the string variant