### PR TITLE
Do not click when selection is active

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -511,6 +511,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
                                 }
                             }
                             li.css('cursor', 'pointer').click(function() {
+                                if (window.getSelection().type == "Range") {
+                                    return''
+                                }
                                 var table = $(this).find('table');
                                 if (table.is(':visible')) {
                                     table.hide();

--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -58,6 +58,9 @@
                         }
                     }
                     li.css('cursor', 'pointer').click(function() {
+                        if (window.getSelection().type == "Range") {
+                            return''
+                        }
                         if (table.is(':visible')) {
                             table.hide();
                         } else {


### PR DESCRIPTION
Complement of #608

>This could be added to more collectors probably, but basically:
If a selection range is active, prevent the click behavior. Especially useful for thinks like copying paths etc.

This fix the same problem for Templates widget, and Timeline widget([CacheCollector](https://github.com/barryvdh/laravel-debugbar/blob/6fd181adc9981aebc8fa50a54ba49d31c751ef1d/src/Resources/cache/widget.js#L11), [ViewCollector](https://github.com/barryvdh/laravel-debugbar/blob/6fd181adc9981aebc8fa50a54ba49d31c751ef1d/src/DataCollector/ViewCollector.php#L43))