### PR TITLE
Keeps only the main debugbar functionality on iframes

### DIFF
--- a/demo/iframes/iframe1.php
+++ b/demo/iframes/iframe1.php
@@ -1,0 +1,13 @@
+<?php
+
+include '../bootstrap.php';
+
+$debugbarRenderer->setBaseUrl('../../src/DebugBar/Resources');
+
+$debugbar['messages']->addMessage('I\'m a IFRAME');
+
+render_demo_page(function() {
+?>
+<iframe src="iframe2.php" style="display:none;"></iframe>
+<?php
+});

--- a/demo/iframes/iframe2.php
+++ b/demo/iframes/iframe2.php
@@ -1,0 +1,9 @@
+<?php
+
+include '../bootstrap.php';
+
+$debugbarRenderer->setBaseUrl('../../src/DebugBar/Resources');
+
+$debugbar['messages']->addMessage('I\'m a Deeper Hidden Iframe');
+
+render_demo_page(function() {});

--- a/demo/iframes/index.php
+++ b/demo/iframes/index.php
@@ -1,0 +1,13 @@
+<?php
+
+include '../bootstrap.php';
+
+$debugbarRenderer->setBaseUrl('../../src/DebugBar/Resources');
+
+$debugbar['messages']->addMessage('Top Page(Main debugbar)');
+
+render_demo_page(function() {
+?>
+<iframe src="iframe1.php" height="350" style="width:100%;"></iframe>
+<?php
+});

--- a/demo/index.php
+++ b/demo/index.php
@@ -31,6 +31,10 @@ render_demo_page(function() {
     <li><a href="ajax.php" class="ajax">load ajax content</a></li>
     <li><a href="ajax_exception.php" class="ajax">load ajax content with exception</a></li>
 </ul>
+<h2>IFRAMES</h2>
+<ul>
+    <li><a href="iframes/index.php">load through iframes</a></li>
+</ul>
 <h2>Stack</h2>
 <ul>
     <li><a href="stack.php">perform a redirect</a></li>

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -424,6 +424,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.activePanelName = null;
             this.datesetTitleFormater = new DatasetTitleFormater(this);
             this.options.bodyMarginBottomHeight = parseInt($('body').css('margin-bottom'));
+            this.hasParent = window.parent && window.parent !== window.top
+                && window.parent.phpdebugbar && window.parent.phpdebugbar != this;
             this.registerResizeHandler();
         },
 
@@ -433,7 +435,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @this {DebugBar}
          */
         registerResizeHandler: function() {
-            if (typeof this.resize.bind == 'undefined') return;
+            if (typeof this.resize.bind == 'undefined' || this.hasParent) return;
 
             var f = this.resize.bind(this);
             this.respCSSSize = 0;
@@ -474,6 +476,10 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @this {DebugBar}
          */
         render: function() {
+            if (this.hasParent) {
+                this.$el.hide();
+            }
+
             var self = this;
             this.$el.appendTo('body');
             this.$dragCapture = $('<div />').addClass(csscls('drag-capture')).appendTo(this.$el);
@@ -573,6 +579,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @this {DebugBar}
          */
         restoreState: function() {
+            if (this.hasParent) return;
             // bar height
             var height = localStorage.getItem('phpdebugbar-height');
             this.setHeight(height || this.$body.height());
@@ -923,6 +930,15 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @return {String} Dataset's id
          */
         addDataSet: function(data, id, suffix, show) {
+            if (this.hasParent) {
+                if (!suffix || ('(iframe)').indexOf(suffix) < 0) {
+                    suffix = '(iframe)' + (suffix || '');
+                }
+                
+                window.parent.phpdebugbar.addDataSet(data, id, suffix, show);
+                return;
+            }
+
             var label = this.datesetTitleFormater.format(id, data, suffix);
             id = id || (getObjectSize(this.datasets) + 1);
             this.datasets[id] = data;


### PR DESCRIPTION
`window.parent != window.top` added to prevent infinite loops(SPA, Livewire, Hotwire https://github.com/maximebf/php-debugbar/pull/613#issuecomment-1988807700)

Alternative to https://github.com/maximebf/php-debugbar/pull/452#issuecomment-1936976144

>We needed a way to add them to the debugbar. (a bit like it happens with ajax+headers).
The debugbar is opened in the top frame, and when something happens inside the iframes, the changes are being added to the top-level debugbar.

![image](https://github.com/maximebf/php-debugbar/assets/4933954/ae7bb23c-2e8b-46d4-a443-e0ff73f79205)
Some iframes may be hidden or small, this PR propagates data from iframes to the top main debugbar and also it prevents size errors caused by small iframes(the inside smaller iframe change web storage like height, that affects the main debugbar)

Closes #614