### PR TITLE
Filter collectors on MessagesWidget

### DIFF
--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -81,7 +81,7 @@ div.phpdebugbar-widgets-messages {
   height: 100%;
 }
   div.phpdebugbar-widgets-messages ul.phpdebugbar-widgets-list {
-    padding-bottom: 20px;
+    padding-bottom: 45px;
   }
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value:before {
     font-family: PhpDebugbarFontAwesome;


### PR DESCRIPTION
- This PR adds a second filter group to MessageCollector, MessageCollector could [aggreate](https://github.com/maximebf/php-debugbar/blob/c7d2cfba153139c40f757adff58e0f29ac4c8cd8/src/DebugBar/DataCollector/MessagesCollector.php#L113) other `MessagesAggregateInterface`, With this PR it is easier to filter messages from a certain collector([#1560](https://github.com/barryvdh/laravel-debugbar/pull/1560))
- Another problem that is solved is if there is only one label/collector, it is not necessary to add the filter, because it removes/displays all the messages
- In case there are unlabeled messages, the `NONE` filter is added, which allows them to be filtered; previously it was not possible to filter this type of messages
- There was a CSS problem, the bottom only took into account the search bar, but not the filters, sometimes the filters obstruct the view of the message, I did increase enough padding to display correctly

>![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/1afc4af5-e906-4a92-86a9-f790db90fa09)
