### PR TITLE
Fix html body mail on SwiftMailCollector

### DIFF
--- a/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php
+++ b/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php
@@ -43,11 +43,13 @@ class SwiftMailCollector extends DataCollector implements Renderable, AssetProvi
     {
         $mails = array();
         foreach ($this->messagesLogger->getMessages() as $msg) {
+            $html = $this->showBody ? $msg->getBody() : null;
             $mails[] = array(
                 'to' => $this->formatTo($msg->getTo()),
                 'subject' => $msg->getSubject(),
                 'headers' => $msg->getHeaders()->toString(),
-                'body' => $this->showBody ? $msg->getBody() : null,
+                'body' => $html,
+                'html' => $html,
             );
         }
         return array(


### PR DESCRIPTION
- Issue introduced on #617

After #617, SwiftMailCollector stop showing messages body preview,
Now `html` array key is needed

https://github.com/maximebf/php-debugbar/blob/0b407703b08ea0cf6ebc61e267cc96ff7000911b/src/DebugBar/Bridge/Symfony/SymfonyMailCollector.php#L65-L66