### PR TITLE
Add dataset tab instead of dropdown

### DIFF
--- a/src/DebugBar/DataCollector/DatasetCollector.php
+++ b/src/DebugBar/DataCollector/DatasetCollector.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * This file is part of the DebugBar package.
+ *
+ * (c) 2013 Maxime Bouroumeau-Fuseau
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DebugBar\DataCollector;
+
+/**
+ * Collects array data
+ */
+class DatasetCollector extends DataCollector implements Renderable, AssetProvider
+{
+
+
+    /**
+     * @return array
+     */
+    public function collect()
+    {
+        return [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Datasets';
+    }
+
+    /**
+     * @return array
+     */
+    public function getWidgets()
+    {
+        return array(
+            "__datasets" => array(
+                "icon" => "history",
+                "title" => "Requests",
+                "widget" => 'PhpDebugBar.Widgets.DatasetListWidget',
+                "default" => "{}",
+                "position" => "right"
+            )
+        );
+    }
+
+    function getAssets()
+    {
+        return [];
+    }
+}

--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -11,6 +11,7 @@
 namespace DebugBar;
 
 use DebugBar\DataCollector\AssetProvider;
+use DebugBar\DataCollector\DatasetCollector;
 use DebugBar\DataCollector\Renderable;
 
 /**
@@ -1124,7 +1125,8 @@ class JavascriptRenderer
                 }
             }
         }
-        $controls = array_merge($widgets, $this->controls);
+
+        $controls = array_merge($widgets, $this->controls, (new DatasetCollector())->getWidgets());
 
         foreach (array_filter($controls) as $name => $options) {
             $opts = array_diff_key($options, array_flip($excludedOptions));
@@ -1133,12 +1135,13 @@ class JavascriptRenderer
                 if (!isset($opts['title'])) {
                     $opts['title'] = ucfirst(str_replace('_', ' ', $name));
                 }
-                $js .= sprintf("%s.addTab(\"%s\", new %s({%s%s}));\n",
+                $js .= sprintf("%s.addTab(\"%s\", new %s({%s%s}), \"%s\");\n",
                     $varname,
                     $name,
                     isset($options['tab']) ? $options['tab'] : 'PhpDebugBar.DebugBar.Tab',
                     substr(json_encode($opts, JSON_FORCE_OBJECT), 1, -1),
-                    isset($options['widget']) ? sprintf('%s"widget": new %s()', count($opts) ? ', ' : '', $options['widget']) : ''
+                    isset($options['widget']) ? sprintf('%s"widget": new %s()', count($opts) ? ', ' : '', $options['widget']) : '',
+                    isset($options['position']) ? $options['position'] : 'left'
                 );
             } elseif (isset($options['indicator']) || isset($options['icon'])) {
                 $js .= sprintf("%s.addIndicator(\"%s\", new %s(%s), \"%s\");\n",

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -544,13 +544,6 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 });
             });
 
-            // select box for data sets
-            this.$datasets = $('<select />').addClass(csscls('datasets-switcher')).attr('name', 'datasets-switcher')
-                .appendTo(this.$headerRight);
-            this.$datasets.change(function() {
-                self.dataChangeHandler(self.datasets[this.value]);
-                self.showTab();
-            });
         },
 
         /**
@@ -624,13 +617,13 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @param {Tab} tab Tab object
          * @return {Tab}
          */
-        addTab: function(name, tab) {
+        addTab: function(name, tab, position) {
             if (this.isControl(name)) {
                 throw new Error(name + ' already exists');
             }
 
             var self = this;
-            tab.$tab.appendTo(this.$headerLeft).click(function() {
+            tab.$tab.appendTo(position == 'right' ? this.$headerRight : this.$headerLeft).click(function() {
                 if (!self.isMinimized() && self.activePanelName == name) {
                     self.minimize();
                 } else {
@@ -934,7 +927,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 if (!suffix || ('(iframe)').indexOf(suffix) < 0) {
                     suffix = '(iframe)' + (suffix || '');
                 }
-                
+
                 window.parent.phpdebugbar.addDataSet(data, id, suffix, show);
                 return;
             }
@@ -943,10 +936,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             id = id || (getObjectSize(this.datasets) + 1);
             this.datasets[id] = data;
 
-            this.$datasets.append($('<option value="' + id + '">' + label + '</option>'));
-            if (this.$datasets.children().length > 1) {
-                this.$datasets.show();
-            }
+            var control = this.getControl('__datasets');
+            control.set('data', this.datasets);
+            control.set('badge', getObjectSize(this.datasets));
 
             if (typeof(show) == 'undefined' || show) {
                 this.showDataSet(id);
@@ -991,7 +983,6 @@ if (typeof(PhpDebugBar) == 'undefined') {
          */
         showDataSet: function(id) {
             this.dataChangeHandler(this.datasets[id]);
-            this.$datasets.val(id);
         },
 
         /**

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -270,6 +270,26 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
     });
 
+    /**
+     * An extension of KVListWidget where the data represents incoming requsts
+     *
+     * Options:
+     *  - data
+     */
+    var DatasetListWidget = PhpDebugBar.Widgets.DatasetListWidget = KVListWidget.extend({
+
+        className: csscls('kvlist datasetlist'),
+
+        itemRenderer: function(dt, dd, key, value) {
+            dt.text(key);
+            dd.html(value.__meta.uri );
+            dd.on('click', function() {
+                window.phpdebugbar.showDataSet(key);
+            })
+        }
+
+    });
+
     // ------------------------------------------------------------------
 
     /**


### PR DESCRIPTION
Current dropdown has the following issues:
 - closes when updates (eg if a dataset is added before choosing)
 - Limited info
 - Can get long

So the idea is this:

 - Create a new tab for datasets, instead of de dropdown
 - Show more data on the tabs
 - Maybe add some advanced controls, like pausing the auto-refresh (often requested), filtering requests (like open handler) or maybe show some badge indicators (number of queries, mails sent) to jump to that tab directly.

Rough prototype in PR:
![image](https://github.com/maximebf/php-debugbar/assets/973269/ed32ac89-caf5-4cf1-bfe9-cff62fd3af0c)

Thoughts:
 - Maybe separate into new widget file
 - Table based would be better instead of dd/dt
 - Configurable?
