### PR TITLE
Feat deprecate bindtojquery

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -72,9 +72,9 @@ class JavascriptRenderer
 
     protected $ajaxHandlerBindToFetch = false;
 
-    protected $ajaxHandlerBindToJquery = true;
+    protected $ajaxHandlerBindToJquery = false;
 
-    protected $ajaxHandlerBindToXHR = false;
+    protected $ajaxHandlerBindToXHR = true;
 
     protected $ajaxHandlerAutoShow = true;
 
@@ -1085,10 +1085,8 @@ class JavascriptRenderer
             if ($this->ajaxHandlerBindToFetch) {
                 $js .= sprintf("%s.ajaxHandler.bindToFetch();\n", $this->variableName);
             }
-            if ($this->ajaxHandlerBindToXHR) {
+            if ($this->ajaxHandlerBindToXHR || $this->ajaxHandlerBindToJquery) {
                 $js .= sprintf("%s.ajaxHandler.bindToXHR();\n", $this->variableName);
-            } elseif ($this->ajaxHandlerBindToJquery) {
-                $js .= sprintf("if (jQuery) %s.ajaxHandler.bindToJquery(jQuery);\n", $this->variableName);
             }
         }
 

--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -509,6 +509,7 @@ class JavascriptRenderer
      * Sets whether to call bindToJquery() on the ajax handler
      *
      * @param boolean $bind
+     * @deprecated use setBindAjaxHandlerToXHR
      */
     public function setBindAjaxHandlerToJquery($bind = true)
     {
@@ -520,6 +521,7 @@ class JavascriptRenderer
      * Checks whether bindToJquery() will be called on the ajax handler
      *
      * @return boolean
+     * @deprecated use isAjaxHandlerBoundToXHR
      */
     public function isAjaxHandlerBoundToJquery()
     {
@@ -1085,8 +1087,10 @@ class JavascriptRenderer
             if ($this->ajaxHandlerBindToFetch) {
                 $js .= sprintf("%s.ajaxHandler.bindToFetch();\n", $this->variableName);
             }
-            if ($this->ajaxHandlerBindToXHR || $this->ajaxHandlerBindToJquery) {
+            if ($this->ajaxHandlerBindToXHR) {
                 $js .= sprintf("%s.ajaxHandler.bindToXHR();\n", $this->variableName);
+            } elseif ($this->ajaxHandlerBindToJquery) {
+                $js .= sprintf("if (jQuery) %s.ajaxHandler.bindToJquery(jQuery);\n", $this->variableName);
             }
         }
 

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -934,7 +934,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 if (!suffix || ('(iframe)').indexOf(suffix) < 0) {
                     suffix = '(iframe)' + (suffix || '');
                 }
-                
+
                 window.parent.phpdebugbar.addDataSet(data, id, suffix, show);
                 return;
             }
@@ -1203,10 +1203,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
         },
 
         /**
-         * Attaches an event listener to jQuery.ajaxComplete()
-         *
-         * @this {AjaxHandler}
-         * @param {jQuery} jq Optional
+         * @deprecated use bindToXHR instead
          */
         bindToJquery: function(jq) {
             var self = this;

--- a/tests/DebugBar/Tests/full_init.html
+++ b/tests/DebugBar/Tests/full_init.html
@@ -9,5 +9,5 @@ phpdebugbar.setDataMap({
 });
 phpdebugbar.restoreState();
 phpdebugbar.ajaxHandler = new PhpDebugBar.AjaxHandler(phpdebugbar, undefined, true);
-if (jQuery) phpdebugbar.ajaxHandler.bindToJquery(jQuery);
+phpdebugbar.ajaxHandler.bindToXHR();
 phpdebugbar.addDataSet(


### PR DESCRIPTION
I don't think it is useful anymore. We're using bindToXhr for years in laravel-debugbar without issues.