### PR TITLE
Normalize line height on `li` tag

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -59,6 +59,10 @@ div.phpdebugbar ol, div.phpdebugbar ul {
   list-style: none;
 }
 
+div.phpdebugbar ul li, div.phpdebugbar ol li, div.phpdebugbar dl li {
+  line-height: 1;
+}
+
 div.phpdebugbar table {
   border-collapse: collapse;
   border-spacing: 0;


### PR DESCRIPTION
Other css files change php-debugbar `li` and grows too much