### PR TITLE
Fix label on dataset tab

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -798,7 +798,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
             var clickHandler = function() {
                 var debugbar = widget.get('debugbar');
-                debugbar.showDataSet(meta['id']);
+                debugbar.showDataSet(meta.id, debugbar.datesetTitleFormater.format('', data, meta.suffix, meta.nb));
                 widget.$table.find('.' + csscls('active')).removeClass(csscls('active'));
                 tr.addClass(csscls('active'));
 


### PR DESCRIPTION
The label is not appearing when I select an item from the request history
![image](https://github.com/maximebf/php-debugbar/assets/4933954/5c96b342-8f77-4527-b1d5-1f4bde607007)
