### PR TITLE
Suggest that the line is unknown when is null/zero on xdebug link

### DIFF
--- a/src/DebugBar/DataFormatter/HasXdebugLinks.php
+++ b/src/DebugBar/DataFormatter/HasXdebugLinks.php
@@ -81,7 +81,7 @@ trait HasXdebugLinks
                 'url' => $url,
                 'ajax' => $this->getXdebugShouldUseAjax(),
                 'filename' => basename($file),
-                'line' => (string) $line
+                'line' => (string) $line ?: '?'
             ];
         }
     }


### PR DESCRIPTION
When the line is null it shows an empty value but link points to line 1, show `?` on the info
https://github.com/maximebf/php-debugbar/blob/94a16d787468500a2170da628fbd7577910ada84/src/DebugBar/DataFormatter/HasXdebugLinks.php#L77