### PR TITLE
fix `cross-origin` iframe and no parent debugbar

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -427,7 +427,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.options.bodyMarginBottomHeight = parseInt($('body').css('margin-bottom'));
             try {
                 this.isIframe = window.self !== window.top && window.top.phpdebugbar;
-            } catch (error) {}
+            } catch (error) {
+                this.isIframe = false;
+            }
             this.registerResizeHandler();
         },
 

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -425,7 +425,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.activeDatasetId = null;
             this.datesetTitleFormater = new DatasetTitleFormater(this);
             this.options.bodyMarginBottomHeight = parseInt($('body').css('margin-bottom'));
-            this.isIframe = window.self !== window.top;
+            try {
+                this.isIframe = window.self !== window.top && window.top.phpdebugbar;
+            } catch (error) {}
             this.registerResizeHandler();
         },
 


### PR DESCRIPTION
Closes #650
```
Failed to read a named property 'phpdebugbar' from 'Window': 
Blocked a frame with origin "https://[subdomain].ngrok-free.app" from accessing a cross-origin frame.
    at child.addDataSet (https://[subdomain].ngrok-free.app/_debugbar/assets/javascript?v=1712740545:949:28)
    at https://[subdomain].ngrok-free.app/admin/dashboard?shop=[subdomain].myshopify.com&host=[...]:633:13
```
