### PR TITLE
Fix not rendering correctly in some cases

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -1212,7 +1212,7 @@ class JavascriptRenderer
     {
         $js = sprintf("%s.addDataSet(%s, \"%s\"%s);\n",
             $this->variableName,
-            json_encode($data),
+            json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_INVALID_UTF8_IGNORE),
             $requestId,
             $suffix ? ", " . json_encode($suffix) : ''
         );


### PR DESCRIPTION
Thank you for your developing!

I found the debug bar is not displayed correctly when the query string contains "<!--<script>" (confirmed with maximebf/debugbar v1.22.3).
This pull request fixes the issue. Please check it out.

Pattern 1: sample query string
```
?<!--<script>
```

Pattern 2: sample code
```
$debugbar["messages"]->addMessage("<!--<script>");
```