### PR TITLE
Fix `$query['params']` can be "null"

### DIFF
--- a/src/DebugBar/Bridge/DoctrineCollector.php
+++ b/src/DebugBar/Bridge/DoctrineCollector.php
@@ -83,7 +83,7 @@ class DoctrineCollector extends DataCollector implements Renderable, AssetProvid
     public function getParameters($query) : array
     {
         $params = [];
-        foreach ($query['params'] as $name => $param) {
+        foreach ($query['params'] ?? [] as $name => $param) {
             $params[$name] = htmlentities($param?:"", ENT_QUOTES, 'UTF-8', false);
         }
         return $params;


### PR DESCRIPTION
Closes #662
>error in the DoctrineCollector. For some reason, the value of $query['params'] can be "null". The query who triggered this in my case was a "START TRANSACTION" with no others parameters. Because of that the foreach loop in that function fails with a "foreach() argument must be of type array|object, null given" error.