### PR TITLE
Fix link alignment issue

### DIFF
--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -110,8 +110,9 @@ div.phpdebugbar-widgets-messages {
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-critical:before {
     content: "\f057";
   }
+  dl.phpdebugbar-widgets-kvlist dd.phpdebugbar-widgets-value pre.sf-dump,
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item pre.sf-dump {
-    display: inline;
+    display: inline-block !important;
   }
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector,
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-label {


### PR DESCRIPTION
Closes https://github.com/barryvdh/laravel-debugbar/issues/1644

> In the `HtmlVariableListWidget` widget the alignment breaks when you the vardumper output as value and a xdebug link:
> 
> ![image](https://github.com/user-attachments/assets/43ee592f-a3d1-459d-8020-b9fbdd6490ff)
> 
> The links are pushed down by the vardumper element and disappear behind the gray rows.

Fixed
![image](https://github.com/user-attachments/assets/f3e0dab6-79d0-4226-80e9-146582b4a04c)


