### PR TITLE
Add actionable interface for usage in openhandler

### DIFF
--- a/src/DebugBar/DataCollector/Actionable.php
+++ b/src/DebugBar/DataCollector/Actionable.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of the DebugBar package.
+ *
+ * (c) 2013 Maxime Bouroumeau-Fuseau
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DebugBar\DataCollector;
+
+/**
+ * Indicates that a DataCollector is able to run action use the OpenHandler
+ */
+interface Actionable
+{
+    /**
+     * Execute an action with a possible payload.
+     *
+     * @param string $action
+     * @param array|null $payload
+     * @return mixed
+     */
+    function executionAction($action, array $payload = null);
+}

--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -48,6 +48,8 @@ class DebugBar implements ArrayAccess
 
     protected $stackAlwaysUseSessionStorage = false;
 
+    protected $hashKey;
+
     /**
      * Adds a data collector
      *
@@ -466,6 +468,22 @@ class DebugBar implements ArrayAccess
             $this->jsRenderer = new JavascriptRenderer($this, $baseUrl, $basePath);
         }
         return $this->jsRenderer;
+    }
+
+    public function setHashKey($key)
+    {
+        $this->hashKey = $key;
+    }
+
+    public function getHashSignature($data)
+    {
+        if ($this->hashKey === null) {
+            throw new DebugBarException('HashKey must be set before running actions');
+        }
+
+        $data = json_encode($data);
+
+        return hash_hmac('sha256', $data, $this->hashKey);
     }
 
     // --------------------------------------------

--- a/src/DebugBar/OpenHandler.php
+++ b/src/DebugBar/OpenHandler.php
@@ -10,6 +10,8 @@
 
 namespace DebugBar;
 
+use DebugBar\DataCollector\Actionable;
+
 /**
  * Handler to list and open saved dataset
  */
@@ -47,7 +49,7 @@ class OpenHandler
         $op = 'find';
         if (isset($request['op'])) {
             $op = $request['op'];
-            if (!in_array($op, array('find', 'get', 'clear'))) {
+            if (!in_array($op, array('find', 'get', 'clear', 'execute'))) {
                 throw new DebugBarException("Invalid operation '{$request['op']}'");
             }
         }
@@ -113,5 +115,36 @@ class OpenHandler
     {
         $this->debugBar->getStorage()->clear();
         return array('success' => true);
+    }
+
+    /**
+     * Execute an action
+     * @param $request
+     * @return mixed
+     * @throws DebugBarException
+     */
+    protected function execute($request)
+    {
+        if (!isset($request['collector']) || !isset($request['action']) || !isset($request['signature'])) {
+            throw new DebugBarException("Missing 'collector' and/or 'action' parameter in 'execute' operation");
+        }
+
+        // Get the signature and remove if before checking the payload.
+        $signature = $request['signature'];
+        unset ($request['signature']);
+        if (!hash_equals($this->debugBar->getHashSignature($request), $signature)) {
+            throw new DebugBarException("Signature does not match in 'execute' operation");
+        }
+
+        if (!$this->debugBar->hasCollector($request['collector'])) {
+            throw new DebugBarException("Collector {$request['collector']} not found in 'execute' operation");
+        }
+
+        $collector = $this->debugBar->getCollector($request['collector']);
+        if (!$collector instanceof Actionable) {
+            throw new DebugBarException("Collector {$request['collector']} found in 'execute' operation does not implement the Actionable interface");
+        }
+
+        return $collector->executionAction($request['action'], $request['payload'] ?? null);
     }
 }


### PR DESCRIPTION
Rough prototype of ability to run action through the openhandler. Downside is that collectors do not have access to the Debugbar instance, so not sure how to best generate those links. Would also only be possible to run actions generated by the server, but this is a security enhancement as we want to avoid unsafe actions.

Similar example is running Explain commands https://github.com/barryvdh/laravel-debugbar/pull/1648 and the CacheController https://github.com/barryvdh/laravel-debugbar/blob/master/src/Controllers/CacheController.php