### PR TITLE
Fix parameter output if parameter is Datetime or array [v1.22.4]

### DIFF
--- a/src/DebugBar/Bridge/DoctrineCollector.php
+++ b/src/DebugBar/Bridge/DoctrineCollector.php
@@ -84,7 +84,15 @@ class DoctrineCollector extends DataCollector implements Renderable, AssetProvid
     {
         $params = [];
         foreach ($query['params'] ?? [] as $name => $param) {
-            $params[$name] = htmlentities($param?:"", ENT_QUOTES, 'UTF-8', false);
+            if (is_string($param) || is_numeric($param)) {
+                $params[$name] = htmlentities($param, ENT_QUOTES, 'UTF-8', false);
+            } elseif ($param instanceof \DateTimeInterface) {
+                $params[$name] = $param->format('Y-m-d H:i:s');
+            } elseif (is_array($param)) {
+                $params[$name] = implode(', ', $param);
+            } else {
+                $params[$name] = $param ?: '';
+            }
         }
         return $params;
     }

--- a/src/DebugBar/Bridge/DoctrineCollector.php
+++ b/src/DebugBar/Bridge/DoctrineCollector.php
@@ -82,19 +82,16 @@ class DoctrineCollector extends DataCollector implements Renderable, AssetProvid
      */
     public function getParameters($query) : array
     {
-        $params = [];
-        foreach ($query['params'] ?? [] as $name => $param) {
-            if (is_string($param) || is_numeric($param)) {
-                $params[$name] = htmlentities($param, ENT_QUOTES, 'UTF-8', false);
-            } elseif ($param instanceof \DateTimeInterface) {
-                $params[$name] = $param->format('Y-m-d H:i:s');
+        return array_map(function ($param) {
+            if (is_string($param)) {
+                return htmlentities($param, ENT_QUOTES, 'UTF-8', false);
             } elseif (is_array($param)) {
-                $params[$name] = implode(', ', $param);
-            } else {
-                $params[$name] = $param ?: '';
+                return implode(', ', $param);
+            } elseif ($param instanceof \DateTimeInterface) {
+                return $param->format('Y-m-d H:i:s');
             }
-        }
-        return $params;
+            return $param ?: '';
+        }, $query['params'] ?? []);
     }
 
     /**


### PR DESCRIPTION
Version: [v1.22.4](https://github.com/maximebf/php-debugbar/releases/tag/v1.22.4)
Change causing crash: Escape doctrine entries by @barryvdh in https://github.com/maximebf/php-debugbar/pull/657

Fixes error:
```php
Error (E_ERROR):	htmlentities(): Argument #1 ($string) must be of type string, DateTime given
File:	/.../vendor/maximebf/debugbar/src/DebugBar/Bridge/DoctrineCollector.php
Line:	87
```

If passing Datetime instance to Doctrine ORM QueryBuilder.
```php
$doctrineOrmQueryBuilder
    ->andWhere("item.date_from <= :date_from")
    ->setParameter('date_from', new \DateTime($array['date_from']), Types::DATE_MUTABLE);
```

Also fixes argument output if array is given.

![image](https://github.com/user-attachments/assets/f1ec3aac-dfcb-4df4-aa42-c986828eba01)
