### PR TITLE
Hide empty collectors until used

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -62,7 +62,7 @@ class JavascriptRenderer
 
     protected $useRequireJs = false;
 
-    protected $hideEmptyTabs = false;
+    protected $hideEmptyTabs = null;
 
     protected $initialization;
 

--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -62,6 +62,8 @@ class JavascriptRenderer
 
     protected $useRequireJs = false;
 
+    protected $hideEmptyTabs = false;
+
     protected $initialization;
 
     protected $controls = array();
@@ -156,6 +158,9 @@ class JavascriptRenderer
         }
         if (array_key_exists('use_requirejs', $options)) {
             $this->setUseRequireJs($options['use_requirejs']);
+        }
+        if (array_key_exists('hide_empty_tabs', $options)) {
+            $this->setHideEmptyTabs($options['hide_empty_tabs']);
         }
         if (array_key_exists('controls', $options)) {
             foreach ($options['controls'] as $name => $control) {
@@ -395,6 +400,29 @@ class JavascriptRenderer
     public function isRequireJsUsed()
     {
         return $this->useRequireJs;
+    }
+
+
+    /**
+     * Sets whether to hide empty tabs or not
+     *
+     * @param boolean $hide
+     * @return $this
+     */
+    public function setHideEmptyTabs($hide = true)
+    {
+        $this->hideEmptyTabs = $hide;
+        return $this;
+    }
+
+    /**
+     * Checks if empty tabs are hidden or not
+     *
+     * @return boolean
+     */
+    public function areEmptyTabsHidden()
+    {
+        return $this->hideEmptyTabs;
     }
 
     /**
@@ -1036,7 +1064,7 @@ class JavascriptRenderer
     public function replaceTagInBuffer($here = true, $initialize = true, $renderStackedData = true, $head = false)
     {
         $render = ($head ? $this->renderHead() : "")
-                . $this->render($initialize, $renderStackedData);
+            . $this->render($initialize, $renderStackedData);
 
         $current = ($here && ob_get_level() > 0) ? ob_get_clean() : self::REPLACEABLE_TAG;
 
@@ -1075,7 +1103,7 @@ class JavascriptRenderer
 
         $nonce = $this->getNonceAttribute();
 
-	if ($nonce != '') {
+        if ($nonce != '') {
             $js = preg_replace("/<script>/", "<script nonce='{$this->cspNonce}'>", $js);
         }
 
@@ -1098,6 +1126,11 @@ class JavascriptRenderer
 
         if (($this->initialization & self::INITIALIZE_CONSTRUCTOR) === self::INITIALIZE_CONSTRUCTOR) {
             $js .= sprintf("var %s = new %s();\n", $this->variableName, $this->javascriptClass);
+        }
+
+        if ($this->hideEmptyTabs !== null) {
+            $js .= sprintf("%s.setHideEmptyTabs(%s);\n", $this->variableName,
+                json_encode($this->hideEmptyTabs));
         }
 
         if (($this->initialization & self::INITIALIZE_CONTROLS) === self::INITIALIZE_CONTROLS) {

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -255,7 +255,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
         className: csscls('panel'),
 
         render: function() {
-            this.$tab = $('<a />').addClass(csscls('tab')).hide();
+            this.$tab = $('<a />').addClass(csscls('tab'));
             this.$icon = $('<i />').appendTo(this.$tab);
             this.bindAttr('icon', function(icon) {
                 if (icon) {
@@ -425,6 +425,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.firstTabName = null;
             this.activePanelName = null;
             this.activeDatasetId = null;
+            this.hideEmptyTabs = false;
             this.datesetTitleFormater = new DatasetTitleFormater(this);
             this.options.bodyMarginBottomHeight = parseInt($('body').css('margin-bottom'));
             try {
@@ -643,7 +644,10 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 } else {
                     self.showTab(name);
                 }
-            });
+            })
+            if (this.hideEmptyTabs) {
+                tab.$tab.hide();
+            }
             tab.$tab.attr('data-collector', name);
             tab.$el.attr('data-collector', name);
             tab.$el.appendTo(this.$body);
@@ -1056,6 +1060,10 @@ if (typeof(PhpDebugBar) == 'undefined') {
             } else {
                 this.$openbtn.hide();
             }
+        },
+
+        setHideEmptyTabs: function(hideEmpty) {
+            this.hideEmptyTabs = hideEmpty;
         },
 
         /**

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -255,8 +255,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
         className: csscls('panel'),
 
         render: function() {
-            this.$tab = $('<a />').addClass(csscls('tab'));
-
+            this.$tab = $('<a />').addClass(csscls('tab')).hide();
             this.$icon = $('<i />').appendTo(this.$tab);
             this.bindAttr('icon', function(icon) {
                 if (icon) {
@@ -285,6 +284,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.bindAttr('data', function(data) {
                 if (this.has('widget')) {
                     this.get('widget').set('data', data);
+                    if (!$.isEmptyObject(data)) {
+                        this.$tab.show();
+                    }
                 }
             })
         }

--- a/tests/DebugBar/Tests/JavascriptRendererTest.php
+++ b/tests/DebugBar/Tests/JavascriptRendererTest.php
@@ -147,6 +147,13 @@ class JavascriptRendererTest extends DebugBarTestCase
         $this->assertStringStartsWith("<script type=\"text/javascript\" nonce=\"mynonce\">\nvar phpdebugbar = new PhpDebugBar.DebugBar();", $this->r->render());
     }
 
+    public function testRenderConstructorWithEmptyTabsHidden()
+    {
+        $this->r->setInitialization(JavascriptRenderer::INITIALIZE_CONSTRUCTOR);
+        $this->r->setHideEmptyTabs(true);
+        $this->assertStringStartsWith("<script type=\"text/javascript\">\nvar phpdebugbar = new PhpDebugBar.DebugBar();\nphpdebugbar.setHideEmptyTabs(true);", $this->r->render());
+    }
+
     public function testJQueryNoConflictAutoDisabling()
     {
         $this->assertTrue($this->r->isJqueryNoConflictEnabled());


### PR DESCRIPTION
This will hide empty collectors, until the collector is actually filled using any data.
This can be useful for less-used collectors without filling up te screen.

Note:
 - It is not hidden when empty, to keep a more consistent flow when using ajax etc.
 - it's not using the badge because not every collector uses a badge

Not sure if it's worth creating a config option for.