### PR TITLE
Enable copy, tweak icon

### DIFF
--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.css
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.css
@@ -57,6 +57,10 @@ div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-stmt-id:before {
 }
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-copy-clipboard:before {
   content: "\f0c5";
+  line-height: 1.5;
+}
+div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-copy-clipboard-check:before {
+  content: "\f46c";
 }
 div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-editor-link:before {
   content: "\f08e";

--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.js
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.js
@@ -21,7 +21,10 @@
             var copy = function () {
                 try {
                     document.execCommand('copy');
-                    alert('Query copied to the clipboard');
+                    $(el).addClass(csscls('copy-clipboard-check'));
+                    setTimeout(function(){
+                        $(el).removeClass(csscls('copy-clipboard-check'));
+                    }, 2000)
                 } catch (err) {
                     console.log('Oops, unable to copy');
                 }
@@ -116,7 +119,7 @@
                     li.addClass(csscls('error'));
                     li.append($('<span />').addClass(csscls('error')).text("[" + stmt.error_code + "] " + stmt.error_message));
                 }
-                if ((!stmt.type || stmt.type === 'query') && stmt.show_copy !== false) {
+                if ((!stmt.type || stmt.type === 'query')) {
                     $('<span title="Copy to clipboard" />')
                         .addClass(csscls('copy-clipboard'))
                         .css('cursor', 'pointer')


### PR DESCRIPTION
Instead of the alert, toggle the copy button with a similar icon for 2 seconds, to indicate success.
<img width="422" alt="image" src="https://github.com/user-attachments/assets/48ebc3c4-6216-4025-8b9b-d5d01ee3e0a6">
