### PR TITLE
Fix parameter output if parameter is zero [v1.23.0]

### DIFF
--- a/src/DebugBar/Bridge/DoctrineCollector.php
+++ b/src/DebugBar/Bridge/DoctrineCollector.php
@@ -87,6 +87,8 @@ class DoctrineCollector extends DataCollector implements Renderable, AssetProvid
                 return htmlentities($param, ENT_QUOTES, 'UTF-8', false);
             } elseif (is_array($param)) {
                 return implode(', ', $param);
+            } elseif (is_numeric($param)) {
+                return strval($param);
             } elseif ($param instanceof \DateTimeInterface) {
                 return $param->format('Y-m-d H:i:s');
             }


### PR DESCRIPTION
Version: [v1.23.0](https://github.com/maximebf/php-debugbar/releases/tag/v1.23.0)

Improved output when zero is parameter.

![image](https://github.com/user-attachments/assets/4c0fa035-df6d-43a6-bf57-4c3198d3ac19)
