### PR TITLE
Replace implicit nullable types in parameter declarations

### DIFF
--- a/demo/bootstrap.php
+++ b/demo/bootstrap.php
@@ -20,7 +20,7 @@ $debugbarRenderer = $debugbar->getJavascriptRenderer()
 // $debugbar->setStorage(new DebugBar\Storage\RedisStorage(new Predis\Client()));
 // $debugbarRenderer->setOpenHandlerUrl('open.php');
 
-function render_demo_page(Closure $callback = null)
+function render_demo_page(?Closure $callback = null)
 {
     global $debugbarRenderer;
 ?>

--- a/src/DebugBar/Bridge/CacheCacheCollector.php
+++ b/src/DebugBar/Bridge/CacheCacheCollector.php
@@ -38,7 +38,7 @@ class CacheCacheCollector extends MonologCollector
      * @param bool $level
      * @param bool $bubble
      */
-    public function __construct(Cache $cache = null, Logger $logger = null, $level = Logger::DEBUG, $bubble = true)
+    public function __construct(?Cache $cache = null, ?Logger $logger = null, $level = Logger::DEBUG, $bubble = true)
     {
         parent::__construct(null, $level, $bubble);
 

--- a/src/DebugBar/Bridge/MonologCollector.php
+++ b/src/DebugBar/Bridge/MonologCollector.php
@@ -37,7 +37,7 @@ class MonologCollector extends AbstractProcessingHandler implements DataCollecto
      * @param boolean $bubble
      * @param string $name
      */
-    public function __construct(Logger $logger = null, $level = Logger::DEBUG, $bubble = true, $name = 'monolog')
+    public function __construct(?Logger $logger = null, $level = Logger::DEBUG, $bubble = true, $name = 'monolog')
     {
         parent::__construct($level, $bubble);
         $this->name = $name;

--- a/src/DebugBar/Bridge/PropelCollector.php
+++ b/src/DebugBar/Bridge/PropelCollector.php
@@ -49,7 +49,7 @@ class PropelCollector extends DataCollector implements BasicLogger, Renderable, 
      *
      * @param PropelConfiguration $config Apply profiling on a specific config
      */
-    public static function enablePropelProfiling(PropelConfiguration $config = null)
+    public static function enablePropelProfiling(?PropelConfiguration $config = null)
     {
         if ($config === null) {
             $config = Propel::getConfiguration(PropelConfiguration::TYPE_OBJECT);
@@ -74,7 +74,7 @@ class PropelCollector extends DataCollector implements BasicLogger, Renderable, 
      * @param LoggerInterface $logger A logger to forward non-query log lines to
      * @param PropelPDO $conn Bound this collector to a connection only
      */
-    public function __construct(LoggerInterface $logger = null, PropelPDO $conn = null)
+    public function __construct(?LoggerInterface $logger = null, ?PropelPDO $conn = null)
     {
         if ($conn) {
             $conn->setLogger($this);

--- a/src/DebugBar/Bridge/Twig/TimeableTwigExtensionProfiler.php
+++ b/src/DebugBar/Bridge/Twig/TimeableTwigExtensionProfiler.php
@@ -36,7 +36,7 @@ class TimeableTwigExtensionProfiler extends ProfilerExtension
         $this->timeDataCollector = $timeDataCollector;
     }
 
-    public function __construct(Profile $profile, TimeDataCollector $timeDataCollector = null)
+    public function __construct(Profile $profile, ?TimeDataCollector $timeDataCollector = null)
     {
         parent::__construct($profile);
 

--- a/src/DebugBar/Bridge/Twig/TraceableTwigEnvironment.php
+++ b/src/DebugBar/Bridge/Twig/TraceableTwigEnvironment.php
@@ -24,7 +24,7 @@ use Twig_TokenStream;
 
 /**
  * Wrapped a Twig Environment to provide profiling features
- * 
+ *
  * @deprecated
  */
 class TraceableTwigEnvironment extends Twig_Environment
@@ -39,7 +39,7 @@ class TraceableTwigEnvironment extends Twig_Environment
      * @param Twig_Environment $twig
      * @param TimeDataCollector $timeDataCollector
      */
-    public function __construct(Twig_Environment $twig, TimeDataCollector $timeDataCollector = null)
+    public function __construct(Twig_Environment $twig, ?TimeDataCollector $timeDataCollector = null)
     {
         $this->twig = $twig;
         $this->timeDataCollector = $timeDataCollector;

--- a/src/DebugBar/DataCollector/PDO/PDOCollector.php
+++ b/src/DebugBar/DataCollector/PDO/PDOCollector.php
@@ -26,7 +26,7 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
      * @param \PDO $pdo
      * @param TimeDataCollector $timeCollector
      */
-    public function __construct(\PDO $pdo = null, TimeDataCollector $timeCollector = null)
+    public function __construct(?\PDO $pdo = null, ?TimeDataCollector $timeCollector = null)
     {
         $this->timeCollector = $timeCollector;
         if ($pdo !== null) {
@@ -138,7 +138,7 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
      * @param string|null $connectionName the pdo connection (eg default | read | write)
      * @return array
      */
-    protected function collectPDO(TraceablePDO $pdo, TimeDataCollector $timeCollector = null, $connectionName = null)
+    protected function collectPDO(TraceablePDO $pdo, ?TimeDataCollector $timeCollector = null, $connectionName = null)
     {
         if (empty($connectionName) || $connectionName == 'default') {
             $connectionName = 'pdo';

--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -57,7 +57,7 @@ class TracedStatement
      * @param float $endTime
      * @param int $endMemory
      */
-    public function end(\Exception $exception = null, int $rowCount = 0, float $endTime = null, int $endMemory = null) : void
+    public function end(?\Exception $exception = null, int $rowCount = 0, ?float $endTime = null, ?int $endMemory = null) : void
     {
         $this->endTime = $endTime ?: microtime(true);
         $this->duration = $this->endTime - $this->startTime;

--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -146,7 +146,7 @@ class DebugBar implements ArrayAccess
      * @param StorageInterface $storage
      * @return $this
      */
-    public function setStorage(StorageInterface $storage = null)
+    public function setStorage(?StorageInterface $storage = null)
     {
         $this->storage = $storage;
         return $this;


### PR DESCRIPTION
In PHP 8.4, implicit nullable parameter types are deprecated; see also https://wiki.php.net/rfc/deprecate-implicitly-nullable-types.

This MR changes occurrences of this pattern.

See also https://github.com/barryvdh/laravel-debugbar/pull/1632.