### PR TITLE
Remove trace args in Exceptions

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -97,18 +97,21 @@ class ExceptionsCollector extends DataCollector implements Renderable
                 if (isset($track['file'])) {
                     $track['file'] = $this->normalizeFilePath($track['file']);
                 }
-
-                if (isset($track['args'])) {
-                    foreach ($track['args'] as $key => $arg) {
-                        if (is_object($arg)) {
-                            $track['args'][$key] = '[object ' . $this->getDataFormatter()->formatClassName($arg) . ']';
-                        }
-                    }
-                }
-
                 return $track;
             }, $trace);
         }
+
+        // Remove large objects from the trace
+        $trace = array_map(function ($track) {
+            if (isset($track['args'])) {
+                foreach ($track['args'] as $key => $arg) {
+                    if (is_object($arg)) {
+                        $track['args'][$key] = '[object ' . $this->getDataFormatter()->formatClassName($arg) . ']';
+                    }
+                }
+            }
+            return $track;
+        }, $trace);
 
         return $trace;
     }


### PR DESCRIPTION
Currently when dumping Exceptions, this will contain the argument object, which can be quite heavy and can contain sensitive information. 

This replaces the arguments with just the object classname, which will improve performance and reduce the size of the traces.

![image](https://github.com/user-attachments/assets/3cc23e6a-9892-4364-93fc-d286a13c25ab)
