### PR TITLE
Fix Panic Nova link template

### DIFF
--- a/src/DebugBar/DataFormatter/HasXdebugLinks.php
+++ b/src/DebugBar/DataFormatter/HasXdebugLinks.php
@@ -120,7 +120,7 @@ trait HasXdebugLinks
             'vscode-remote' => 'vscode://vscode-remote/%f:%l',
             'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/%f:%l',
             'vscodium' => 'vscodium://file/%f:%l',
-            'nova' => 'nova://core/open/file?filename=%f&line=%l',
+            'nova' => 'nova://open?path=%f&line=%l',
             'xdebug' => 'xdebug://%f@%l',
             'atom' => 'atom://core/open/file?filename=%f&line=%l',
             'espresso' => 'x-espresso://open?filepath=%f&lines=%l',


### PR DESCRIPTION
The URL scheme for Nova is incorrect; per Panic's recent post (https://social.panic.com/@panic/112689904216756608) this now uses the correct format. This is tested (briefly) with Laravel for confirmation.

(N.B.: I am assuming the "nova" setting for editors here is indeed meant to be Panic Nova and not another Nova I'm unfamiliar with!)