### PR TITLE
Support html messages on MessagesCollector

### DIFF
--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -71,7 +71,7 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
     public function addMessage($message, $label = 'info', $isString = true)
     {
         $messageText = $message;
-        $messageHtml = null;
+        $messageHtml = !$isString ? $message : null;
         if (!is_string($message)) {
             // Send both text and HTML representations; the text version is used for searches
             $messageText = $this->getDataFormatter()->formatVar($message);

--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -67,6 +67,7 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
      *
      * @param mixed $message
      * @param string $label
+     * @param bool|string $isString
      */
     public function addMessage($message, $label = 'info', $isString = true)
     {

--- a/src/DebugBar/DataCollector/MessagesCollector.php
+++ b/src/DebugBar/DataCollector/MessagesCollector.php
@@ -71,7 +71,7 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
     public function addMessage($message, $label = 'info', $isString = true)
     {
         $messageText = $message;
-        $messageHtml = !$isString ? $message : null;
+        $messageHtml = null;
         if (!is_string($message)) {
             // Send both text and HTML representations; the text version is used for searches
             $messageText = $this->getDataFormatter()->formatVar($message);
@@ -79,6 +79,8 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
                 $messageHtml = $this->getVarDumper()->renderVar($message);
             }
             $isString = false;
+        } elseif (! $isString) {
+            $messageHtml = $this->cleanHtml($message);
         }
 
         $stackItem = [];
@@ -193,6 +195,14 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
 
         // interpolate replacement values into the message and return
         return strtr($message, $replace);
+    }
+
+    private function cleanHtml($html) {
+        $cleanHtml = strip_tags($html, '<b><i><p><a><ul><ol><li><strong><em><span><div>');
+        $cleanHtml = preg_replace('/\s*on\w+\s*=\s*"[^"]*"|\s*on\w+\s*=\s*\'[^\']*\'/i', '', $cleanHtml);
+        $cleanHtml = preg_replace('/href\s*=\s*["\']?\s*javascript:[^"\']*/i', 'href="#"', $cleanHtml);
+
+        return $cleanHtml;
     }
 
     /**

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -339,7 +339,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                     var val = $('<span />').addClass(csscls('value')).text(m).appendTo(li);
                     if (!value.is_string || value.message.length > 100) {
                         var prettyVal = value.message;
-                        if (!value.is_string) {
+                        if (value.is_string !== true) {
                             prettyVal = null;
                         }
                         li.css('cursor', 'pointer').click(function () {
@@ -349,7 +349,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                             if (val.hasClass(csscls('pretty'))) {
                                 val.text(m).removeClass(csscls('pretty'));
                             } else {
-                                prettyVal = prettyVal || createCodeBlock(value.message, 'php');
+                                prettyVal = prettyVal || createCodeBlock(value.message, value.is_string || 'php');
                                 val.addClass(csscls('pretty')).empty().append(prettyVal);
                             }
                         });


### PR DESCRIPTION
From https://github.com/barryvdh/laravel-debugbar/issues/1654#issuecomment-2637599284
>Unfortunately, no URLs allowed
>```php
>Debugbar::getCollector('Quick Links')->addMessage('<a href="https://google.com">Test</a>');
>```
![image](https://github.com/user-attachments/assets/ad8c1eec-b273-4fe9-a5ee-8adc3ef13187)

----
**Now:**
```php
Debugbar::getCollector('Quick Links')->addMessage('<a href="https://google.com">Test</a>', 'links', false);
```
![image](https://github.com/user-attachments/assets/7504ad35-e180-4d47-851d-fb2d0bcc3ac0)
