### PR TITLE
Hide TimeDataCollector extending tabs

### DIFF
--- a/src/DebugBar/DataCollector/TimeDataCollector.php
+++ b/src/DebugBar/DataCollector/TimeDataCollector.php
@@ -238,6 +238,7 @@ class TimeDataCollector extends DataCollector implements Renderable
         });
 
         return array(
+            'count' => count($this->measures),
             'start' => $this->requestStartTime,
             'end' => $this->requestEndTime,
             'duration' => $this->getRequestDuration(),


### PR DESCRIPTION
Many classes extend from this, it would be better if they could be hidden by default