### PR TITLE
Fix debugbar resize

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -780,7 +780,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
          */
         setHeight: function(height) {
             var min_h = 40;
-            var max_h = $(window).innerHeight() - this.$header.height() - 10;
+            var max_h = window.innerHeight - this.$header.height() - 10;
             height = Math.min(height, max_h);
             height = Math.max(height, min_h);
             this.$body.css('height', height);


### PR DESCRIPTION
I don't understand why it happens, but jquery gives me wrong values ​​and this functionality fails
Could it be a Chrome problem?
![image](https://github.com/user-attachments/assets/dec8d119-2fe9-473d-90ff-5c23880aab36)
