### PR TITLE
Fix param namesposition on templates widget

### DIFF
--- a/src/DebugBar/Resources/widgets/templates/widget.css
+++ b/src/DebugBar/Resources/widgets/templates/widget.css
@@ -70,4 +70,5 @@ div.phpdebugbar-widgets-templates table.phpdebugbar-widgets-params td {
 div.phpdebugbar-widgets-templates table.phpdebugbar-widgets-params .phpdebugbar-widgets-name {
   width: 20%;
   font-weight: bold;
+  vertical-align: top;
 }


### PR DESCRIPTION
`vertical-align: top;`, same as other widgets params name
https://github.com/php-debugbar/php-debugbar/blob/27be4c47a346bc458a4e50b78fd10076a7e9be7b/src/DebugBar/Resources/widgets.css#L278-L282