### PR TITLE
Slow threshold highlight on queries

### DIFF
--- a/src/DebugBar/DataCollector/PDO/PDOCollector.php
+++ b/src/DebugBar/DataCollector/PDO/PDOCollector.php
@@ -22,6 +22,8 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
 
     protected $durationBackground = false;
 
+    protected $slowThreshold;
+
     /**
      * @param \PDO $pdo
      * @param TimeDataCollector $timeCollector
@@ -53,6 +55,16 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
     public function setDurationBackground($enabled)
     {
         $this->durationBackground = $enabled;
+    }
+
+    /**
+     * Highlights queries that exceed the threshold
+     *
+     * @param  int|float $threshold miliseconds value
+     */
+    public function setSlowThreshold($threshold)
+    {
+        $this->slowThreshold = $threshold;
     }
 
     /**
@@ -162,7 +174,8 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
                 'end_memory_str' => $this->getDataFormatter()->formatBytes($stmt->getEndMemory()),
                 'is_success' => $stmt->isSuccess(),
                 'error_code' => $stmt->getErrorCode(),
-                'error_message' => $stmt->getErrorMessage()
+                'error_message' => $stmt->getErrorMessage(),
+                'slow' => $this->slowThreshold && $this->slowThreshold <= $stmt->getDuration()
             );
             if ($timeCollector !== null) {
                 $timeCollector->addMeasure($stmt->getSql(), $stmt->getStartTime(), $stmt->getEndTime(), array(), $connectionName);

--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.css
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.css
@@ -98,12 +98,20 @@ code.phpdebugbar-widgets-sql {
   word-wrap: break-word;
 }
 
+div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-sql-slow {
+  background-color: #ffe4e4;
+}
+
 div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-sql-duplicate {
-  background-color: #F7EDED;
+  background-color: #fdfdcd;
+}
+
+div.phpdebugbar[data-theme='dark'] div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-sql-slow {
+  background-color: #623100;
 }
 
 div.phpdebugbar[data-theme='dark'] div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-sql-duplicate {
-    background-color: #473e00;
+    background-color: #565602;
 }
 
 div.phpdebugbar-widgets-sqlqueries div.phpdebugbar-widgets-toolbar {

--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.js
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.js
@@ -74,6 +74,9 @@
             var filters = [], self = this;
 
             this.$list = new PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, stmt) {
+                if (stmt.slow) {
+                    li.addClass(csscls('sql-slow'))
+                }
                 if (stmt.width_percent) {
                     $('<div />').addClass(csscls('bg-measure')).append(
                         $('<div />').addClass(csscls('value')).css({


### PR DESCRIPTION
https://github.com/php-debugbar/php-debugbar/pull/703#issuecomment-3074656340

```php
$debugbar['pdo']->setSlowThreshold(100); // time on ms
```

<img width="609" height="226" alt="image" src="https://github.com/user-attachments/assets/1ad85e60-20fd-4dd1-972d-7bad96ce89aa" />

<img width="438" height="200" alt="image" src="https://github.com/user-attachments/assets/c1a63131-a0e2-4696-ad45-2b92036e0ee1" />
