### PR TITLE
Stop click event propagation on templates editor links

### DIFF
--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -26,13 +26,13 @@
                 if (typeof tpl.xdebug_link !== 'undefined' && tpl.xdebug_link !== null) {
                     var header = $('<span />').addClass(csscls('filename')).text(tpl.xdebug_link.filename + ( tpl.xdebug_link.line ? "#" + tpl.xdebug_link.line : ''));
                     if (tpl.xdebug_link) {
-                        if (tpl.xdebug_link.ajax) {
-                            $('<a title="' + tpl.xdebug_link.url + '"></a>').on('click', function () {
+                        $('<a href="' + tpl.xdebug_link.url + '"></a>').on('click', function () {
+                            event.stopPropagation();
+                            if (tpl.xdebug_link.ajax) {
                                 fetch(tpl.xdebug_link.url);
-                            }).addClass(csscls('editor-link')).appendTo(header);
-                        } else {
-                            $('<a href="' + tpl.xdebug_link.url + '"></a>').addClass(csscls('editor-link')).appendTo(header);
-                        }
+                                event.preventDefault();
+                            }
+                        }).addClass(csscls('editor-link')).appendTo(header);
                     }
                     header.appendTo(li);
                 }


### PR DESCRIPTION
Click event opens params table when editor links clicked

Same fix as other widgets (`event.stopPropagation();`): 
https://github.com/php-debugbar/php-debugbar/blob/3146d04671f51f69ffec2a4207ac3bdcf13a9f35/src/DebugBar/Resources/widgets/sqlqueries/widget.js#L130-L136