### PR TITLE
Avoid triggering click when range selection on VariableListWidget

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -235,6 +235,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             }
             var prettyVal = null;
             dd.text(v).click(function() {
+                if (window.getSelection().type == "Range") {
+                    return '';
+                }
                 if (dd.hasClass(csscls('pretty'))) {
                     dd.text(v).removeClass(csscls('pretty'));
                 } else {


### PR DESCRIPTION
Same as other widgets
https://github.com/php-debugbar/php-debugbar/blob/3146d04671f51f69ffec2a4207ac3bdcf13a9f35/src/DebugBar/Resources/widgets/templates/widget.js#L66-L68