### PR TITLE
Avoid same warning many times

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -89,6 +89,8 @@ class ExceptionsCollector extends DataCollector implements Renderable
     {
         $hash = md5("{$errno}-{$errstr}-{$errfile}-{$errline}");
         if (isset($this->existingWarnings[$hash])) {
+            $this->existingWarnings[$hash]['count']++;
+
             return;
         }
 
@@ -110,8 +112,8 @@ class ExceptionsCollector extends DataCollector implements Renderable
             16384 => 'E_USER_DEPRECATED'
         );
 
-        $this->existingWarnings[$hash] = true;
-        $this->exceptions[] = array(
+        $warning = array(
+            'count' => 1,
             'type' => $errorTypes[$errno] ?? 'UNKNOWN',
             'message' => $errstr,
             'code' => $errno,
@@ -119,6 +121,8 @@ class ExceptionsCollector extends DataCollector implements Renderable
             'line' => $errline,
             'xdebug_link' => $this->getXdebugLink($errfile, $errline)
         );
+        $this->exceptions[] = &$warning;
+        $this->existingWarnings[$hash] = &$warning;
     }
 
 

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -19,6 +19,7 @@ use Symfony\Component\Debug\Exception\FatalThrowableError;
 class ExceptionsCollector extends DataCollector implements Renderable
 {
     protected $exceptions = array();
+    protected $existingWarnings = array();
     protected $chainExceptions = false;
 
     /**
@@ -86,6 +87,11 @@ class ExceptionsCollector extends DataCollector implements Renderable
      */
     public function addWarning($errno, $errstr, $errfile = '', $errline = 0)
     {
+        $hash = md5("{$errno}-{$errstr}-{$errfile}-{$errline}");
+        if (isset($this->existingWarnings[$hash])) {
+            return;
+        }
+
         $errorTypes = array(
             1    => 'E_ERROR',
             2    => 'E_WARNING',
@@ -104,6 +110,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
             16384 => 'E_USER_DEPRECATED'
         );
 
+        $this->existingWarnings[$hash] = true;
         $this->exceptions[] = array(
             'type' => $errorTypes[$errno] ?? 'UNKNOWN',
             'message' => $errstr,

--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -355,7 +355,7 @@ table.phpdebugbar-widgets-tablevar td {
   font-weight: normal;
 }
 
-table.phpdebugbar-widgets-tablevar .phpdebugbar-widgets-header span.phpdebugbar-widgets-badge {
+div.phpdebugbar span.phpdebugbar-widgets-badge {
   margin: 0 5px 0 8px;
   font-size: 11px;
   line-height: 14px;

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -701,7 +701,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
         render: function() {
             this.$list = new ListWidget({ itemRenderer: function(li, e) {
-                $('<span />').addClass(csscls('message')).text(e.message).appendTo(li);
+                $('<span />').addClass(csscls('message')).text(e.message)
+                    .prepend(e.count>1 ? $('<span />').addClass(csscls('badge')).text(e.count+'x') : '').appendTo(li);
                 if (e.file) {
                     var header = $('<span />').addClass(csscls('filename')).text(e.file + "#" + e.line);
                     if (e.xdebug_link) {


### PR DESCRIPTION
If the warning is inside a for loop(or the same method called several times), the same message is repeated too many times,

this allows only one instance of each message to be displayed.