### PR TITLE
Fix tablevar widget font size

### DIFF
--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -327,6 +327,7 @@ div.phpdebugbar[data-theme='dark'] .phpdebugbar-widgets-success > pre.sf-dump > 
 table.phpdebugbar-widgets-tablevar {
   width: 100%;
   table-layout: auto;
+  font-size: 1em;
 }
 
 table.phpdebugbar-widgets-tablevar td:first-child {


### PR DESCRIPTION
In certain particular cases this table increases the font size, it is better to declare it so that it always maintains consistency
https://github.com/php-debugbar/php-debugbar/blob/c9a88bbc89958ccdab95734ad396cc82f8c65e43/src/DebugBar/Resources/debugbar.css#L181