### PR TITLE
Fix variable name encoding in load dataset code(renderer)

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -1245,7 +1245,7 @@ class JavascriptRenderer
     {
         $js = sprintf(
             "%s.loadDataSet(%s, %s, %s);\n",
-            json_encode($this->variableName),
+            $this->variableName,
             json_encode($requestId),
             json_encode($suffix ?: ''),
             json_encode($show),

--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -1244,7 +1244,7 @@ class JavascriptRenderer
     protected function getLoadDatasetCode(string $requestId, ?string $suffix = null, bool $show = true): string
     {
         $js = sprintf(
-            "%s.loadDataSet(%s, %s, %s);\n",
+            "%s.loadDataSet(%s, %s, null, %s);\n",
             $this->variableName,
             json_encode($requestId),
             json_encode($suffix ?: ''),


### PR DESCRIPTION
it give me js error

<img width="222" height="81" alt="image" src="https://github.com/user-attachments/assets/4b6450c9-6195-4c3e-98c5-fcaded92a40f" />


Update: `show` it's the fourth arg
https://github.com/php-debugbar/php-debugbar/blob/b8d9055e35ec633dd495f483aea390385d8f3eb9/resources/debugbar.js#L1309-L1319
<img width="405" height="168" alt="image" src="https://github.com/user-attachments/assets/79d234d0-9879-490e-a957-c6a2dddc0ea0" />


