### PR TITLE
Remove editor link icon margin on widget CSS

### DIFF
--- a/resources/widgets/templates/widget.css
+++ b/resources/widgets/templates/widget.css
@@ -11,7 +11,6 @@ div.phpdebugbar-widgets-templates div.phpdebugbar-widgets-status {
 div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-render-time,
 div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-memory,
 div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count,
-div.phpdebugbar-widgets-templates a.phpdebugbar-widgets-editor-link,
 div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-type {
   float: right;
   margin-left: 8px;


### PR DESCRIPTION
`span.phpdebugbar-widgets-filename` already has `margin-left: 8px;`
https://github.com/php-debugbar/php-debugbar/blob/d6c5890e2ded72677335308a612467cbb3a23fe9/resources/widgets.css#L35-L40
Closes https://github.com/fruitcake/laravel-debugbar/pull/1828#issuecomment-3715105803