### PR TITLE
Fix iframes support

### DIFF
--- a/demo/bootstrap.php
+++ b/demo/bootstrap.php
@@ -29,7 +29,7 @@ foreach ($debugbar->getCollectors() as $collector) {
 }
 
 $debugbarRenderer = $debugbar->getJavascriptRenderer()
-                             ->setAssetHandlerUrl('assets.php')
+                             ->setAssetHandlerUrl('/assets.php')
                              ->setAjaxHandlerEnableTab(true)
                              ->setHideEmptyTabs(true)
                              ->setUseDistFiles(false)
@@ -49,7 +49,7 @@ $debugbar->setStorage(new DebugBar\Storage\FileStorage(__DIR__ . '/profiles'));
 //    tableName: 'phpdebugbar',
 //));
 
-$debugbarRenderer->setOpenHandlerUrl('open.php');
+$debugbarRenderer->setOpenHandlerUrl('/open.php');
 
 // configs
 // $debugbar->useHtmlVarDumper();

--- a/demo/iframes/iframe2.php
+++ b/demo/iframes/iframe2.php
@@ -9,13 +9,14 @@ $debugbar['messages']->addMessage('I\'m a Deeper Hidden Iframe');
 render_demo_page(function () {
     ?>
 <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {
+    setTimeout(()=>
         fetch('../ajax.php')
             .then(response => response.text())
             .then(data => {
                 //ajax from IFRAME
-            });
-    });
+            }),
+        100
+    )
 </script>
 <?php
 });

--- a/resources/debugbar.js
+++ b/resources/debugbar.js
@@ -704,7 +704,7 @@ window.PhpDebugBar = window.PhpDebugBar || {};
             this.bodyPaddingTopHeight = Number.parseInt(bodyStyles.paddingTop);
 
             try {
-                this.isIframe = window.self !== window.top && window.top.phpdebugbar;
+                this.isIframe = window.self !== window.top && window.top.PhpDebugBar && window.top[window.top.phpdebugbar_variable_name];
             } catch (_error) {
                 this.isIframe = false;
             }
@@ -1391,7 +1391,7 @@ window.PhpDebugBar = window.PhpDebugBar || {};
                 return;
             }
             if (this.isIframe) {
-                window.top.phpdebugbar.addDataSet(data, id, `(iframe)${suffix || ''}`, show);
+                window.top[window.top.phpdebugbar_variable_name].addDataSet(data, id, `(iframe)${suffix || ''}`, show);
                 return;
             }
 

--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -1195,6 +1195,7 @@ class JavascriptRenderer
         $nonce = $this->getNonceAttribute();
 
         return "<script type=\"text/javascript\"{$nonce}>
+var {$this->variableName}, phpdebugbar_variable_name = \"{$this->variableName}\";
 (function () {
     const renderDebugbar = function () {
 $js
@@ -1219,7 +1220,7 @@ $js
 
         if (($this->initialization & self::INITIALIZE_CONSTRUCTOR) === self::INITIALIZE_CONSTRUCTOR) {
             $initializeOptions = $this->getInitializeOptions();
-            $js .= sprintf("var %s = new %s(%s);\n", $this->variableName, $this->javascriptClass, $initializeOptions ? json_encode((object) $initializeOptions) : '');
+            $js .= sprintf("%s = new %s(%s);\n", $this->variableName, $this->javascriptClass, $initializeOptions ? json_encode((object) $initializeOptions) : '');
         }
 
         if (($this->initialization & self::INITIALIZE_CONTROLS) === self::INITIALIZE_CONTROLS) {


### PR DESCRIPTION
https://github.com/php-debugbar/php-debugbar/pull/636#issuecomment-3773737832
<img width="1060" height="370" alt="image" src="https://github.com/user-attachments/assets/4895f89a-ac44-48fa-a187-292af125373b" />



Is there a cleaner way to get the name of the js variable?