### PR TITLE
Compact arrays on ConfigCollector

### DIFF
--- a/src/DataCollector/ConfigCollector.php
+++ b/src/DataCollector/ConfigCollector.php
@@ -42,6 +42,11 @@ class ConfigCollector extends DataCollector implements Renderable, Resettable
         foreach ($data as $k => $v) {
             if (!is_string($v)) {
                 $v = $this->getDataFormatter()->formatVar($v);
+
+                $expanded = strpos((string) $v, 'sf-dump-expanded');
+                if ($expanded !== false) {
+                    $v = substr_replace($v, 'sf-dump-compact', $expanded, 16);
+                }
             }
             $this->data[$k] = $v;
         }


### PR DESCRIPTION
It allows searching more easily when there are many configurations and they are all arrays.

<img width="394" height="296" alt="image" src="https://github.com/user-attachments/assets/d9c1be3c-0447-4ff9-b63e-22d03ee6a6c7" />

Same as 
https://github.com/php-debugbar/php-debugbar/blob/c80ed01a42ecc6220abc1e85e30212cacc171850/src/DataCollector/MessagesCollector.php#L101-L104

Maybe `formatVar` needs an arg for this, like `bool $compact = false`