### PR TITLE
Add sticky header styles for debugbar table var widget

### DIFF
--- a/resources/widgets.css
+++ b/resources/widgets.css
@@ -427,16 +427,19 @@ table.phpdebugbar-widgets-tablevar td {
   font-weight: normal;
 }
 
-table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-header td{
+table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-header td,
+table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-summary td {
   position: sticky;
   inset-inline-start: 0px;
   background: var(--debugbar-background);
   border-bottom: none;
   z-index: 1;
   top: 0;
+  bottom: 0;
 }
 
-table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-header td::after {
+table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-header td::after,
+table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-summary td::after {
   content: "";
   position: absolute;
   left: 0;
@@ -444,6 +447,11 @@ table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-header td::after {
   width: 100%;
   height: 1px;
   background-color: var(--debugbar-border);
+}
+
+table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-summary td::after {
+  bottom: auto;
+  top: 0;
 }
 
 div.phpdebugbar span.phpdebugbar-widgets-badge {

--- a/resources/widgets.css
+++ b/resources/widgets.css
@@ -427,6 +427,25 @@ table.phpdebugbar-widgets-tablevar td {
   font-weight: normal;
 }
 
+table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-header td{
+  position: sticky;
+  inset-inline-start: 0px;
+  background: var(--debugbar-background);
+  border-bottom: none;
+  z-index: 1;
+  top: 0;
+}
+
+table.phpdebugbar-widgets-tablevar tr.phpdebugbar-widgets-header td::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background-color: var(--debugbar-border);
+}
+
 div.phpdebugbar span.phpdebugbar-widgets-badge {
   margin: 0 5px 0 8px;
   font-size: 11px;

--- a/resources/widgets.js
+++ b/resources/widgets.js
@@ -369,6 +369,7 @@
                 if (!data.data) {
                     return;
                 }
+                let hasXdebuglinks = false;
                 for (const [key, values] of Object.entries(data.data)) {
                     const tr = document.createElement('tr');
                     tr.classList.add(csscls('item'));
@@ -416,8 +417,8 @@
                         }
                         filename.append(link);
 
-                        if (!data.xdebug_link) {
-                            data.xdebug_link = true;
+                        if (!hasXdebuglinks) {
+                            hasXdebuglinks = true;
                             header.append(document.createElement('td'));
                         }
                     }
@@ -449,7 +450,7 @@
                     }
                 }
 
-                if (data.xdebug_link) {
+                if (hasXdebuglinks) {
                     summaryTr.append(document.createElement('td'));
                 }
             });


### PR DESCRIPTION
This way, the headings would always be visible if the list is large.

<img width="379" height="135" alt="image" src="https://github.com/user-attachments/assets/05dfa339-1a48-44b6-80c8-5f31e4d78f6a" />

Also applied to the last column, the summary.
