### PR TITLE
Always allow click event on sql type(for sql formatter)

### DIFF
--- a/resources/widgets/sqlqueries/widget.js
+++ b/resources/widgets/sqlqueries/widget.js
@@ -232,6 +232,11 @@
                 errorSpan.textContent = `[${stmt.error_code}] ${stmt.error_message}`;
                 li.append(errorSpan);
             }
+            
+            if (['info', 'transaction'].includes(stmt.type)) {
+                return;
+            }
+
             const table = document.createElement('table');
             table.classList.add(csscls('params'));
             table.hidden = true;
@@ -250,24 +255,25 @@
                 }
                 this.renderList(table, 'Backtrace', values);
             }
-            if (table.querySelectorAll('tr').length) {
-                li.append(table);
-                li.style.cursor = 'pointer';
-                li.addEventListener('click', () => {
-                    if (window.getSelection().type === 'Range') {
-                        return '';
-                    }
-                    table.hidden = !table.hidden;
-                    const code = li.querySelector('code');
-                    if (code && typeof phpdebugbar_sqlformatter !== 'undefined') {
-                        let sql = stmt.sql;
-                        if (!table.hidden) {
-                            sql = phpdebugbar_sqlformatter.format(stmt.sql);
-                        }
-                        code.innerHTML = PhpDebugBar.Widgets.highlight(sql, 'sql');
-                    }
-                });
+            if (!table.querySelectorAll('tr').length) {
+                table.style.display = 'none';
             }
+            li.append(table);
+            li.style.cursor = 'pointer';
+            li.addEventListener('click', () => {
+                if (window.getSelection().type === 'Range') {
+                    return '';
+                }
+                table.hidden = !table.hidden;
+                const code = li.querySelector('code');
+                if (code && typeof phpdebugbar_sqlformatter !== 'undefined') {
+                    let sql = stmt.sql;
+                    if (!table.hidden) {
+                        sql = phpdebugbar_sqlformatter.format(stmt.sql);
+                    }
+                    code.innerHTML = PhpDebugBar.Widgets.highlight(sql, 'sql');
+                }
+            });
         }
 
         render() {


### PR DESCRIPTION
if the query has no parameters, when you click the query is not being formatted 

The table is also not added, and the explain button is added from laravel-debugbar, but since the table doesn't exist, there's no button.

I'll open another PR to resolve it there