### PR TITLE
fix: QueryFormatter::quoteBinding() $binding must be of type string, false given

### DIFF
--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -35,7 +35,20 @@ class QueryFormatter extends DataFormatter
             }
 
             if (is_object($binding)) {
-                $binding =  json_encode($binding);
+                if ($binding instanceof \Closure) {
+                    $binding = '[CLOSURE]';
+                } else {
+                    try {
+                        $binding = json_encode(
+                            $binding,
+                            JSON_INVALID_UTF8_SUBSTITUTE
+                            | JSON_UNESCAPED_UNICODE
+                            | JSON_THROW_ON_ERROR
+                        );
+                    } catch (\JsonException $e) {
+                        $binding = '[object ' . get_class($binding) . ']';
+                    }
+                }
             }
         }
 

--- a/tests/Tests/QueryFormatterTest.php
+++ b/tests/Tests/QueryFormatterTest.php
@@ -467,4 +467,35 @@ class QueryFormatterTest extends DebugBarTestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testBindingWithClosureIsHandled(): void
+    {
+        $formatter = new QueryFormatter();
+
+        $sql = 'SELECT * FROM users WHERE callback = ?';
+        $bindings = [
+            function (): string {
+                return 'test';
+            },
+        ];
+
+        $result = $formatter->formatSqlWithBindings($sql, $bindings);
+
+        $this->assertEquals("SELECT * FROM users WHERE callback = '[CLOSURE]'", $result);
+    }
+
+    public function testBindingWithNonJsonEncodableObjectIsHandled(): void
+    {
+        $formatter = new QueryFormatter();
+
+        $object = new \stdClass();
+        $object->self = $object;
+
+        $sql = 'SELECT * FROM users WHERE data = ?';
+        $bindings = [$object];
+
+        $result = $formatter->formatSqlWithBindings($sql, $bindings);
+
+        $this->assertEquals("SELECT * FROM users WHERE data = '[object stdClass]'", $result);
+    }
 }


### PR DESCRIPTION
Hello!

When the json_encode() function fails, it returns false which causes a TypeError downstream. Instead, we should throw an exception so that the actual cause can be inspected.

In this case, the real error that I was experiencing is json_encode() erroring with `Malformed UTF-8 characters, possibly incorrectly encoded`

Thanks!