### PR TITLE
Handle invalid UTF-8 characters in JSON encoding

### DIFF
--- a/src/DebugBar.php
+++ b/src/DebugBar.php
@@ -318,7 +318,7 @@ class DebugBar implements ArrayAccess
         $data = rawurlencode(json_encode([
             'id' => $this->getCurrentRequestId(),
             'data' => $this->getData(),
-        ]));
+        ], JSON_INVALID_UTF8_SUBSTITUTE));
 
         if (strlen($data) > $maxTotalHeaderLength) {
             $data = rawurlencode(json_encode([

--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -1360,7 +1360,7 @@ $js
         $js = sprintf(
             "%s.addDataSet(%s, %s, %s, %s);\n",
             $this->variableName,
-            json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_INVALID_UTF8_IGNORE),
+            json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_INVALID_UTF8_SUBSTITUTE),
             json_encode($requestId),
             json_encode($suffix ?: ''),
             json_encode($show),

--- a/src/OpenHandler.php
+++ b/src/OpenHandler.php
@@ -69,7 +69,7 @@ class OpenHandler
             throw new DebugBarException("Invalid operation '{$request['op']}'");
         }
 
-        $response = json_encode($response);
+        $response = json_encode($response, JSON_INVALID_UTF8_SUBSTITUTE);
         if ($response === false) {
             throw new DebugBarException("Invalid JSON response");
         }

--- a/src/Storage/FileStorage.php
+++ b/src/Storage/FileStorage.php
@@ -34,7 +34,7 @@ class FileStorage extends AbstractStorage
             mkdir($this->dirname, 0o755, true);
             file_put_contents($this->dirname . '.gitignore', "*\n!.gitignore\n");
         }
-        file_put_contents($this->makeFilename($id), json_encode($data));
+        file_put_contents($this->makeFilename($id), json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE));
 
         $this->autoPrune();
     }

--- a/src/Storage/FileStorage.php
+++ b/src/Storage/FileStorage.php
@@ -54,7 +54,7 @@ class FileStorage extends AbstractStorage
             throw new \RuntimeException("Unable to read file $fileName");
         }
 
-        return json_decode($content, true);
+        return json_decode($content, true) ?: [];
     }
 
     /**

--- a/src/Storage/MemcachedStorage.php
+++ b/src/Storage/MemcachedStorage.php
@@ -46,7 +46,7 @@ class MemcachedStorage extends AbstractStorage
     public function save(string $id, array $data): void
     {
         $key = $this->createKey($id);
-        $this->memcached->set($key, json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE), $this->expiration);
+        $this->memcached->set($key, $data, $this->expiration);
         if (!$this->memcached->append($this->keyNamespace, "|$key")) {
             $this->memcached->set($this->keyNamespace, $key, $this->expiration);
         } elseif ($this->expiration) {
@@ -60,7 +60,7 @@ class MemcachedStorage extends AbstractStorage
      */
     public function get(string $id): array
     {
-        return json_decode($this->memcached->get($this->createKey($id)), true);
+        return $this->memcached->get($this->createKey($id)) ?: [];
     }
 
     /**

--- a/src/Storage/MemcachedStorage.php
+++ b/src/Storage/MemcachedStorage.php
@@ -46,7 +46,7 @@ class MemcachedStorage extends AbstractStorage
     public function save(string $id, array $data): void
     {
         $key = $this->createKey($id);
-        $this->memcached->set($key, $data, $this->expiration);
+        $this->memcached->set($key, json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE), $this->expiration);
         if (!$this->memcached->append($this->keyNamespace, "|$key")) {
             $this->memcached->set($this->keyNamespace, $key, $this->expiration);
         } elseif ($this->expiration) {
@@ -60,7 +60,7 @@ class MemcachedStorage extends AbstractStorage
      */
     public function get(string $id): array
     {
-        return $this->memcached->get($this->createKey($id));
+        return json_decode($this->memcached->get($this->createKey($id)), true);
     }
 
     /**

--- a/src/Storage/PdoStorage.php
+++ b/src/Storage/PdoStorage.php
@@ -52,7 +52,7 @@ class PdoStorage extends AbstractStorage
         $meta = $data['__meta'];
         $stmt->execute([
             $id,
-            json_encode($data),
+            json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE),
             $meta['utime'],
             $meta['datetime'] ?? null,
             $meta['uri'] ?? null,

--- a/src/Storage/PdoStorage.php
+++ b/src/Storage/PdoStorage.php
@@ -72,7 +72,7 @@ class PdoStorage extends AbstractStorage
         $stmt->execute([$id]);
 
         if (($data = $stmt->fetchColumn(0)) !== false) {
-            return json_decode($data, true);
+            return json_decode($data, true) ?: [];
         }
 
         return [];

--- a/src/Storage/RedisStorage.php
+++ b/src/Storage/RedisStorage.php
@@ -48,7 +48,7 @@ class RedisStorage extends AbstractStorage
 
         $entryKey = $this->entryKey($id);
         $metaJson = json_encode($meta);
-        $dataJson = json_encode($data);
+        $dataJson = json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE);
 
         if ($this->isPhpRedis()) {
             /** @var \Redis|\RedisCluster $r */


### PR DESCRIPTION
Closes https://github.com/fruitcake/laravel-debugbar/issues/1958
```php
\Debugbar::log("Text with fix " . "\xC3\xC3\xC3\xC3\xC3" . " end");
```

Before:
<img width="231" height="95" alt="image" src="https://github.com/user-attachments/assets/121b84bf-467c-415a-aa86-66c14958dab6" />
```
TypeError: DebugBar\Storage\FileStorage::get(): Return value must be of type array, null returned
```

**After:**
<img width="206" height="70" alt="image" src="https://github.com/user-attachments/assets/4c9fe6b6-17a6-487a-ac23-f79c38df3544" />


