### PR TITLE
"dot" notation, and `*` wildcard support on masked keys

### DIFF
--- a/src/DataCollector/HidesMaskedValues.php
+++ b/src/DataCollector/HidesMaskedValues.php
@@ -8,16 +8,21 @@ trait HidesMaskedValues
 {
     protected array $maskedKeys = [];
 
+    private array $compiledPatterns = [];
+
     /** @var array|string[]  */
     public static array $SENSITIVE_KEYS = ['password', 'secret', 'token', 'php-auth-pw'];
 
-    public function hideMaskedValues(array $data): mixed
+    public function hideMaskedValues(array $data, ?string $prefix = null): mixed
     {
         foreach ($data as $key => $value) {
+            $prefixed = is_null($prefix) ? null : "$prefix.$key";
             if (is_string($key) && $this->isMaskedKey($key)) {
                 $data[$key] = $this->maskValue($value);
+            } elseif (!is_null($prefix) && $this->isMaskedKey($prefixed)) {
+                $data[$key] = $this->maskValue($value);
             } elseif (is_array($value)) {
-                $data[$key] = $this->hideMaskedValues($value);
+                $data[$key] = $this->hideMaskedValues($value, $prefixed ?? "$key");
             }
         }
 
@@ -30,6 +35,13 @@ trait HidesMaskedValues
             $this->maskedKeys[] = strtolower($key);
         }
         $this->maskedKeys = array_unique($this->maskedKeys);
+        $this->compiledPatterns = [];
+        foreach (array_filter($this->maskedKeys, fn($key) => str_contains($key, '*')) as $pattern) {
+            $regex = preg_quote($pattern, '/');
+            $regex = str_replace('\*', '.*', $regex);
+
+            $this->compiledPatterns[] = '/^' . $regex . '$/u';
+        }
     }
 
     public function maskValue(mixed $value): string
@@ -58,6 +70,12 @@ trait HidesMaskedValues
 
         if (in_array($key, $this->maskedKeys, true)) {
             return true;
+        }
+
+        foreach ($this->compiledPatterns as $pattern) {
+            if (preg_match($pattern, $key)) {
+                return true;
+            }
         }
 
         foreach (static::$SENSITIVE_KEYS as $needle) {

--- a/src/DataCollector/HidesMaskedValues.php
+++ b/src/DataCollector/HidesMaskedValues.php
@@ -8,7 +8,7 @@ trait HidesMaskedValues
 {
     protected array $maskedKeys = [];
 
-    private array $compiledPatterns = [];
+    private array $patterns = [];
 
     /** @var array|string[]  */
     public static array $SENSITIVE_KEYS = ['password', 'secret', 'token', 'php-auth-pw'];
@@ -35,13 +35,10 @@ trait HidesMaskedValues
             $this->maskedKeys[] = strtolower($key);
         }
         $this->maskedKeys = array_unique($this->maskedKeys);
-        $this->compiledPatterns = [];
-        foreach (array_filter($this->maskedKeys, fn($key) => str_contains($key, '*')) as $pattern) {
-            $regex = preg_quote($pattern, '/');
-            $regex = str_replace('\*', '.*', $regex);
-
-            $this->compiledPatterns[] = '/^' . $regex . '$/u';
-        }
+        $this->patterns = array_filter(
+            $this->maskedKeys,
+            fn($key) => (bool) array_filter(['*', '?', '[', ']'], fn($n) => str_contains($key, $n))
+        );
     }
 
     public function maskValue(mixed $value): string
@@ -72,8 +69,8 @@ trait HidesMaskedValues
             return true;
         }
 
-        foreach ($this->compiledPatterns as $pattern) {
-            if (preg_match($pattern, $key)) {
+        foreach ($this->patterns as $pattern) {
+            if (fnmatch($pattern, $key)) {
                 return true;
             }
         }


### PR DESCRIPTION
Like laravel, "dot" notation support to indicate depth
```php
$this->addMaskedKeys(['app.key', 'app.providers.0']);
```
`*` wildcard support
```php
$this->addMaskedKeys(['*_api_key', 'database.*.host', 'database.*.port']);
```

Maybe this is overkill 😅