### PR TITLE
Simplify backtrace rendering in widget.js

### DIFF
--- a/resources/widgets/sqlqueries/widget.js
+++ b/resources/widgets/sqlqueries/widget.js
@@ -91,6 +91,7 @@
                         lineSpan.textContent = `:${value.line}`;
                         valueTd.append(lineSpan);
                     }
+                    tr.append(valueTd);
                 } else {
                     const keyTd = document.createElement('td');
                     keyTd.classList.add('phpdebugbar-text-muted');
@@ -98,7 +99,6 @@
                     tr.append(keyTd);
 
                     const valueTd = document.createElement('td');
-                    valueTd.classList.add('phpdebugbar-text-muted');
                     valueTd.textContent = value;
                     tr.append(valueTd);
                 }
@@ -226,15 +226,7 @@
                 this.renderList(table, 'Params', stmt.params);
             }
             if (stmt.backtrace && Object.keys(stmt.backtrace).length > 0) {
-                const values = [];
-                for (const trace of stmt.backtrace.values()) {
-                    let text = trace.name || trace.file;
-                    if (trace.line) {
-                        text = `${text}:${trace.line}`;
-                    }
-                    values.push(text);
-                }
-                this.renderList(table, 'Backtrace', values);
+                this.renderList(table, 'Backtrace', stmt.backtrace);
             }
             if (!table.querySelectorAll('tr').length) {
                 table.style.display = 'none';

--- a/resources/widgets/sqlqueries/widget.js
+++ b/resources/widgets/sqlqueries/widget.js
@@ -91,6 +91,12 @@
                         lineSpan.textContent = `:${value.line}`;
                         valueTd.append(lineSpan);
                     }
+
+                    if (value.xdebug_link?.url) {
+                        const link = PhpDebugBar.Widgets.editorLink(value.xdebug_link);
+                        valueTd.append(link.querySelector('a'));
+                    }
+
                     tr.append(valueTd);
                 } else {
                     const keyTd = document.createElement('td');


### PR DESCRIPTION
Fix missing `tr.append(valueTd);` bug, now it works with default backtrace
The index is used to determine that trace steps may have been excluded.

<img width="284" height="137" alt="image" src="https://github.com/user-attachments/assets/5f65dee5-ebda-40d5-8de8-07304e391df7" />
