### PR TITLE
Fix message timeline

### DIFF
--- a/src/DataCollector/MessagesCollector.php
+++ b/src/DataCollector/MessagesCollector.php
@@ -101,7 +101,6 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
     /**
      * Returns a simple plain-text representation of a variable for search/display fallback.
      *
-     * @deprecated not use anymore, is done client-side.
      */
     protected function getPlainTextFromVar(mixed $var): string
     {
@@ -212,7 +211,7 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
         ];
 
         if ($this->hasTimeDataCollector()) {
-            $this->addTimeMeasure("[{$label}]: " . substr($messageText, 0, 100), microtime(true));
+            $this->addTimeMeasure("[{$label}]: " . substr($isString ? $message : $this->getPlainTextFromVar($message), 0, 100), microtime(true));
         }
 
     }

--- a/src/DataCollector/MessagesCollector.php
+++ b/src/DataCollector/MessagesCollector.php
@@ -157,25 +157,28 @@ class MessagesCollector extends AbstractLogger implements DataCollectorInterface
             $message = $this->interpolate($message, $context);
         }
 
+        $isString = is_string($message);
+        $formattedMessage = $this->getDataFormatter()->formatVar($message);
+        $messageText = null;
         $messageHtml = null;
         $messageJson = null;
-        if ($message instanceof MessageInterface) {
-            $messageText = $message->getText();
-            $messageHtml = $message->getHtml();
-        } else {
-            $messageText = $this->getDataFormatter()->formatVar($message);
-        }
 
-        $isString = is_string($message);
-        if ($this->isJsonVarDumperUsed()) {
-            $messageJson = $messageText;
-            $messageText = '';
-        } elseif ($this->isHtmlVarDumperUsed()) {
-            $messageHtml = $messageText;
-            if ($this->compactDumps) {
-                $messageHtml = $this->compactMessageDump($messageHtml);
+        if ($isString) {
+            $messageText = $formattedMessage;
+        } else {
+            if ($message instanceof MessageInterface) {
+                $messageText = $message->getText();
+                $messageHtml = $message->getHtml();
+            } elseif ($this->isJsonVarDumperUsed()) {
+                $messageJson = $formattedMessage;
+            } elseif ($this->isHtmlVarDumperUsed()) {
+                $messageHtml = $formattedMessage;
+                if ($this->compactDumps) {
+                    $messageHtml = $this->compactMessageDump($messageHtml);
+                }
+            } else {
+                $messageText = $formattedMessage;
             }
-            $messageText = '';
         }
 
         $contextJson = null;

--- a/tests/Tests/DataCollector/MessagesCollectorTest.php
+++ b/tests/Tests/DataCollector/MessagesCollectorTest.php
@@ -9,6 +9,7 @@ use DebugBar\DataFormatter\HtmlDataFormatter;
 use DebugBar\DataFormatter\JsonDataFormatter;
 use DebugBar\Tests\DebugBarTestCase;
 use DebugBar\DataCollector\MessagesCollector;
+use DebugBar\DataCollector\TimeDataCollector;
 
 class MessagesCollectorTest extends DebugBarTestCase
 {
@@ -130,5 +131,59 @@ class MessagesCollectorTest extends DebugBarTestCase
         // Plain formatter: context holds formatted values, context_json is null
         $this->assertNull($msg['context_json']);
         $this->assertSame('value', $msg['context']['key']);
+    }
+
+    public function testTimeLabelForStringMessage(): void
+    {
+        $c = new MessagesCollector();
+        $t = new TimeDataCollector();
+        $c->setTimeDataCollector($t);
+
+        $c->addMessage('hello world', 'info');
+
+        $measures = $t->getMeasures();
+        $this->assertCount(1, $measures);
+        $this->assertEquals('[info]: hello world', $measures[0]['label']);
+    }
+
+    public function testTimeLabelForArrayMessage(): void
+    {
+        $c = new MessagesCollector();
+        $c->setDataFormatter(new DataFormatter());
+        $t = new TimeDataCollector();
+        $c->setTimeDataCollector($t);
+
+        $c->addMessage(['foo', 'bar', 'baz'], 'warning');
+
+        $measures = $t->getMeasures();
+        $this->assertCount(1, $measures);
+        $this->assertEquals('[warning]: array(3)', $measures[0]['label']);
+    }
+
+    public function testTimeLabelForObjectMessage(): void
+    {
+        $c = new MessagesCollector();
+        $c->setDataFormatter(new DataFormatter());
+        $t = new TimeDataCollector();
+        $c->setTimeDataCollector($t);
+
+        $c->addMessage(new \stdClass(), 'debug');
+
+        $measures = $t->getMeasures();
+        $this->assertCount(1, $measures);
+        $this->assertEquals('[debug]: stdClass', $measures[0]['label']);
+    }
+
+    public function testTimeLabelTruncatesLongMessages(): void
+    {
+        $c = new MessagesCollector();
+        $t = new TimeDataCollector();
+        $c->setTimeDataCollector($t);
+
+        $longMessage = str_repeat('a', 200);
+        $c->addMessage($longMessage, 'info');
+
+        $measures = $t->getMeasures();
+        $this->assertEquals('[info]: ' . str_repeat('a', 100), $measures[0]['label']);
     }
 }

--- a/tests/Tests/DataCollector/MessagesCollectorTest.php
+++ b/tests/Tests/DataCollector/MessagesCollectorTest.php
@@ -98,9 +98,9 @@ class MessagesCollectorTest extends DebugBarTestCase
         $data = $c->collect();
         $msg = $data['messages'][0];
 
-        // message_json holds the formatted message, message is empty
-        $this->assertNotNull($msg['message_json']);
-        $this->assertEmpty($msg['message']);
+        // String messages are kept in message, not message_json
+        $this->assertNull($msg['message_json']);
+        $this->assertNotEmpty($msg['message']);
 
         // context values are in context_json, context keys are null
         $this->assertNotNull($msg['context_json']);


### PR DESCRIPTION
Restore the plain message preview for the timeline.

Also clarifies the text/html/json, and return strings just in the messageText, to speed up searching etc.

Fixes #1053