### PR TITLE
Adjust height of debug bar in fullscreen mode

### DIFF
--- a/resources/debugbar.css
+++ b/resources/debugbar.css
@@ -97,7 +97,7 @@ div.phpdebugbar.phpdebugbar-fullscreen[data-toolbarPosition="top"] {
 
 div.phpdebugbar.phpdebugbar-fullscreen .phpdebugbar-body {
   flex: 1;
-  height: auto !important;
+  height: calc(100% - 32px) !important
 }
 
 div.phpdebugbar.phpdebugbar-fullscreen .phpdebugbar-resize-handle {


### PR DESCRIPTION
I'm testing this feature, and the scroll bar isn't showing up; the content at the bottom of the tabs isn't visible. Are you experiencing this issue?
Before:
<img width="224" height="233" alt="image" src="https://github.com/user-attachments/assets/f350a473-e5f4-4562-901c-93c514f168a2" />
After:
<img width="176" height="215" alt="image" src="https://github.com/user-attachments/assets/413b013c-aad7-45d1-b675-bb2da4ab77ad" />

