### PR TITLE
Fix resource not escaped correctly in QueryFormatter

### DIFF
--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -27,14 +27,11 @@ class QueryFormatter extends DataFormatter
         foreach ($bindings as &$binding) {
             if (is_string($binding) && !mb_check_encoding($binding, 'UTF-8')) {
                 $binding = '[BINARY DATA]';
-            }
-
-            if (is_array($binding)) {
-                $binding = $this->checkBindings($binding);
-                $binding = '[' . implode(',', $binding) . ']';
-            }
-
-            if (is_object($binding)) {
+            } elseif (is_array($binding)) {
+                $binding = '[' . implode(',', $this->checkBindings($binding)) . ']';
+            } elseif (is_resource($binding) || gettype($binding) === 'resource (closed)') {
+                $binding = '[RESOURCE]';
+            } elseif (is_object($binding)) {
                 if ($binding instanceof \Closure) {
                     $binding = '[CLOSURE]';
                 } else {


### PR DESCRIPTION
[laravel/framework/blob/src/Illuminate/Database/Query/Grammars/Grammar.php#L1621](https://github.com/laravel/framework/blob/ff97ab481f3e2abf8b122e0294838649c8748ac2/src/Illuminate/Database/Query/Grammars/Grammar.php#L1621)

Closes https://github.com/fruitcake/laravel-debugbar/issues/2029