### PR TITLE
Add ZubZet Framework Integration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Integrations with other frameworks:
   - [Joomla](https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/system/debug/debug.php)
   - [Drupal](https://www.drupal.org/project/debugbar)
   - [October CMS](https://github.com/rainlab/debugbar-plugin)
-[Winter CMS](https://packagist.org/packages/winter/wn-debugbar-plugin)
+  - [Winter CMS](https://packagist.org/packages/winter/wn-debugbar-plugin)
+  - [ZubZet Framework (From v1.2.0+)](https://zubzet.com/)
   - Framework-agnostic middleware and PSR-7 with [php-middleware/phpdebugbar](https://github.com/php-middleware/phpdebugbar)
   - [Dotkernel Frontend Application](https://github.com/dotkernel/dot-debugbar)
 


### PR DESCRIPTION
Add a link to the [ZubZet framework](https://github.com/zubzet/framework) in the README

> (drop me a message or submit a PR to add your DebugBar related project here)

Here we are!

In version 1.2.0 we have finally integrated php-debugbar. So far we have implemented the following collectors, more to come:
1. Templates
2. Queries (mysqli) using the sqlqueries widget
3. Monolog (Custom formatting to enable structured logging, using the message component)

If you are interested in the implementation, check out the [namespace](https://github.com/zubzet/framework/tree/develop/src/ErrorHandling/DebugBar) for it.

The PR for it: https://github.com/zubzet/framework/pull/137

Looking forward to implementing more!